### PR TITLE
chore: remove FluentAssertions, upgrade all NuGet packages

### DIFF
--- a/src/SquadTUI/SquadTUI.csproj
+++ b/src/SquadTUI/SquadTUI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hex1b" Version="0.87.0" />
+    <PackageReference Include="Hex1b" Version="0.90.0" />
     <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
   </ItemGroup>
 

--- a/tests/SquadTUI.Tests/E2E/AppNavigationTests.cs
+++ b/tests/SquadTUI.Tests/E2E/AppNavigationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -17,7 +16,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -38,7 +37,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -59,7 +58,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Decisions"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -80,7 +79,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Skills").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Skills"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -101,7 +100,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Activity Log").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Activity Log"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -122,7 +121,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sprint Metrics").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -145,8 +144,8 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -166,7 +165,7 @@ public class AppNavigationTests
         await sequence.ApplyAsync(terminal);
 
         var completed = await Task.WhenAny(runTask, Task.Delay(2000));
-        completed.Should().Be(runTask, "app should exit when Q is pressed");
+        Assert.Equal(runTask, completed);
 
         cts.Cancel();
     }
@@ -181,11 +180,11 @@ public class AppNavigationTests
 
         var snapshot = terminal.CreateSnapshot();
         // NavBar uses emoji labels without bracket wrapping
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
-        snapshot.ContainsText("Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
+        Assert.True(snapshot.ContainsText("Roster"));
         // Should NOT have bracket-style labels like [1]Dashboard
-        snapshot.ContainsText("[1]").Should().BeFalse();
-        snapshot.ContainsText("[2]").Should().BeFalse();
+        Assert.False(snapshot.ContainsText("[1]"));
+        Assert.False(snapshot.ContainsText("[2]"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -201,7 +200,7 @@ public class AppNavigationTests
 
         var snapshot = terminal.CreateSnapshot();
         // [Q]Quit was removed from NavBar
-        snapshot.ContainsText("[Q]Quit").Should().BeFalse();
+        Assert.False(snapshot.ContainsText("[Q]Quit"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -217,7 +216,7 @@ public class AppNavigationTests
 
         var snapshot = terminal.CreateSnapshot();
         // InfoBar was removed — no status bar at bottom
-        snapshot.ContainsText("InfoBar").Should().BeFalse();
+        Assert.False(snapshot.ContainsText("InfoBar"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -238,7 +237,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Theme Selection").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Theme Selection"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -259,7 +258,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Help").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Help"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/CharterNavigationTests.cs
+++ b/tests/SquadTUI.Tests/E2E/CharterNavigationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -24,7 +23,7 @@ public class CharterNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         // Escape from Roster should go to Dashboard
         var backToDashboard = new Hex1bTerminalInputSequenceBuilder()
@@ -34,7 +33,7 @@ public class CharterNavigationTests
         await Task.Delay(200);
 
         snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         // Navigate to Decisions
         var toDecisions = new Hex1bTerminalInputSequenceBuilder()
@@ -44,7 +43,7 @@ public class CharterNavigationTests
         await Task.Delay(200);
 
         snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Decisions"));
 
         // Escape from Decisions should go to Dashboard
         var backAgain = new Hex1bTerminalInputSequenceBuilder()
@@ -54,7 +53,7 @@ public class CharterNavigationTests
         await Task.Delay(200);
 
         snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/DashboardPanelNavigationTests.cs
+++ b/tests/SquadTUI.Tests/E2E/DashboardPanelNavigationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -24,7 +23,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -49,7 +48,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -71,7 +70,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -93,7 +92,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -116,7 +115,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Activity Log").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Activity Log"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -140,7 +139,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Decisions"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -165,7 +164,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sprint Metrics").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -197,7 +196,7 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -213,7 +212,7 @@ public class DashboardPanelNavigationTests
 
         // Default focus is panel 0 — Team Roster header should have reverse video
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         // RightArrow to panel 1 and verify Activity header is visible
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -223,8 +222,8 @@ public class DashboardPanelNavigationTests
         await Task.Delay(200);
 
         snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Activity").Should().BeTrue();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Activity"));
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/DashboardScreenTests.cs
+++ b/tests/SquadTUI.Tests/E2E/DashboardScreenTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 
@@ -16,7 +15,7 @@ public class DashboardScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -31,8 +30,8 @@ public class DashboardScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Tasks:").Should().BeTrue();
-        snapshot.ContainsText("active").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Tasks:"));
+        Assert.True(snapshot.ContainsText("active"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -47,7 +46,7 @@ public class DashboardScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Activity").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Activity"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -62,7 +61,7 @@ public class DashboardScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Decisions"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/DecisionsScreenTests.cs
+++ b/tests/SquadTUI.Tests/E2E/DecisionsScreenTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -23,7 +22,7 @@ public class DecisionsScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Project Architecture").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Project Architecture"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -44,8 +43,8 @@ public class DecisionsScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sonic").Should().BeTrue();
-        snapshot.ContainsText("2026-02-16").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sonic"));
+        Assert.True(snapshot.ContainsText("2026-02-16"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -67,7 +66,7 @@ public class DecisionsScreenTests
 
         var snapshot = terminal.CreateSnapshot();
         // Detail pane now shows selected decision title and content inline
-        snapshot.ContainsText("Date:").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Date:"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/ExtremeWidthTests.cs
+++ b/tests/SquadTUI.Tests/E2E/ExtremeWidthTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 
@@ -17,7 +16,7 @@ public class ExtremeWidthTests
 
         // Should not crash — just verify the terminal renders something
         var snapshot = terminal.CreateSnapshot();
-        snapshot.Should().NotBeNull();
+        Assert.NotNull(snapshot);
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -32,7 +31,7 @@ public class ExtremeWidthTests
         await Task.Delay(300);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.Should().NotBeNull();
+        Assert.NotNull(snapshot);
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -47,9 +46,9 @@ public class ExtremeWidthTests
         await Task.Delay(300);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.Should().NotBeNull();
+        Assert.NotNull(snapshot);
         // Narrow layout shows SquadTUI header
-        snapshot.ContainsText("SquadTUI").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("SquadTUI"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -65,8 +64,8 @@ public class ExtremeWidthTests
 
         var snapshot = terminal.CreateSnapshot();
         // Wide layout should show team roster and activity panels
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
-        snapshot.ContainsText("Activity").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
+        Assert.True(snapshot.ContainsText("Activity"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -81,8 +80,8 @@ public class ExtremeWidthTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
-        snapshot.ContainsText("Activity").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
+        Assert.True(snapshot.ContainsText("Activity"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -97,7 +96,7 @@ public class ExtremeWidthTests
         await Task.Delay(300);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.Should().NotBeNull();
+        Assert.NotNull(snapshot);
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -112,7 +111,7 @@ public class ExtremeWidthTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.Should().NotBeNull();
+        Assert.NotNull(snapshot);
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -127,7 +126,7 @@ public class ExtremeWidthTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -142,7 +141,7 @@ public class ExtremeWidthTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/HelpNavigationTests.cs
+++ b/tests/SquadTUI.Tests/E2E/HelpNavigationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -23,7 +22,7 @@ public class HelpNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Help").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Help"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -44,8 +43,8 @@ public class HelpNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("NAVIGATION").Should().BeTrue();
-        snapshot.ContainsText("ACTIONS").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("NAVIGATION"));
+        Assert.True(snapshot.ContainsText("ACTIONS"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -66,7 +65,7 @@ public class HelpNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("LIST NAVIGATION").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("LIST NAVIGATION"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -92,7 +91,7 @@ public class HelpNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -116,7 +115,7 @@ public class HelpNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/MetricsScreenTests.cs
+++ b/tests/SquadTUI.Tests/E2E/MetricsScreenTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -23,9 +22,9 @@ public class MetricsScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sprint Metrics").Should().BeTrue();
-        snapshot.ContainsText("Sprint Overview").Should().BeTrue();
-        snapshot.ContainsText("Completion Rate:").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sprint Metrics"));
+        Assert.True(snapshot.ContainsText("Sprint Overview"));
+        Assert.True(snapshot.ContainsText("Completion Rate:"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -46,8 +45,8 @@ public class MetricsScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Velocity View").Should().BeTrue();
-        snapshot.ContainsText("Avg Velocity:").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Velocity View"));
+        Assert.True(snapshot.ContainsText("Avg Velocity:"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -68,7 +67,7 @@ public class MetricsScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team size:").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team size:"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -95,7 +94,7 @@ public class MetricsScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Burndown View").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Burndown View"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -124,7 +123,7 @@ public class MetricsScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Velocity View").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Velocity View"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/NavigationEdgeCaseTests.cs
+++ b/tests/SquadTUI.Tests/E2E/NavigationEdgeCaseTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -23,7 +22,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -51,7 +50,7 @@ public class NavigationEdgeCaseTests
 
         var snapshot = terminal.CreateSnapshot();
         // Should end on Metrics (screen 6)
-        snapshot.ContainsText("Sprint Metrics").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -72,7 +71,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -96,7 +95,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sprint Metrics").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -118,7 +117,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -139,7 +138,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -163,7 +162,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sprint Metrics").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -185,7 +184,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -208,7 +207,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -237,7 +236,7 @@ public class NavigationEdgeCaseTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/NoSquadGuardTests.cs
+++ b/tests/SquadTUI.Tests/E2E/NoSquadGuardTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -30,7 +29,7 @@ public class NoSquadGuardTests
 
         var snapshot = terminal.CreateSnapshot();
         // Should still be on NoSquad screen — look for welcome text
-        snapshot.ContainsText("Welcome to SquadTUI").Should().BeTrue(
+        Assert.True(snapshot.ContainsText("Welcome to SquadTUI"),
             $"pressing {key} should not navigate away from NoSquad screen");
 
         cts.Cancel();
@@ -52,7 +51,7 @@ public class NoSquadGuardTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Welcome to SquadTUI").Should().BeTrue(
+        Assert.True(snapshot.ContainsText("Welcome to SquadTUI"),
             "pressing S should not navigate away from NoSquad screen");
 
         cts.Cancel();
@@ -78,7 +77,7 @@ public class NoSquadGuardTests
 
             // Verify we start on NoSquad
             var snapshot1 = terminal.CreateSnapshot();
-            snapshot1.ContainsText("Welcome to SquadTUI").Should().BeTrue();
+            Assert.True(snapshot1.ContainsText("Welcome to SquadTUI"));
 
             // Press C to create squad structure
             var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -89,7 +88,7 @@ public class NoSquadGuardTests
 
             // Should now be on Dashboard
             var snapshot2 = terminal.CreateSnapshot();
-            snapshot2.ContainsText("Dashboard").Should().BeTrue(
+            Assert.True(snapshot2.ContainsText("Dashboard"),
                 "pressing C should create squad and navigate to Dashboard");
 
             cts.Cancel();
@@ -125,10 +124,10 @@ public class NoSquadGuardTests
             await Task.Delay(300);
 
             // Verify .squad structure was created (new directory name)
-            Directory.Exists(Path.Combine(tempDir, ".squad")).Should().BeTrue();
-            Directory.Exists(Path.Combine(tempDir, ".squad", "agents")).Should().BeTrue();
-            File.Exists(Path.Combine(tempDir, ".squad", "team.md")).Should().BeTrue();
-            File.Exists(Path.Combine(tempDir, ".squad", "decisions.md")).Should().BeTrue();
+            Assert.True(Directory.Exists(Path.Combine(tempDir, ".squad")));
+            Assert.True(Directory.Exists(Path.Combine(tempDir, ".squad", "agents")));
+            Assert.True(File.Exists(Path.Combine(tempDir, ".squad", "team.md")));
+            Assert.True(File.Exists(Path.Combine(tempDir, ".squad", "decisions.md")));
 
             cts.Cancel();
             try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/NoSquadScreenTests.cs
+++ b/tests/SquadTUI.Tests/E2E/NoSquadScreenTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -18,7 +17,7 @@ public class NoSquadScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Welcome to SquadTUI").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Welcome to SquadTUI"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -33,7 +32,7 @@ public class NoSquadScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("No squad detected").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("No squad detected"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -52,7 +51,7 @@ public class NoSquadScreenTests
         var hasNpx = snapshot.ContainsText("npx");
         var hasSquad = snapshot.ContainsText("squad");
         var hasAiTeam = snapshot.ContainsText(".ai-team");
-        (hasNpx || hasSquad || hasAiTeam).Should().BeTrue(
+        Assert.True(hasNpx || hasSquad || hasAiTeam,
             "NoSquad screen should contain setup instructions mentioning npx, squad, or .ai-team");
 
         cts.Cancel();
@@ -68,7 +67,7 @@ public class NoSquadScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Create").Should().BeTrue(
+        Assert.True(snapshot.ContainsText("Create"),
             "NoSquad screen should show the C key instruction for creating squad structure");
 
         cts.Cancel();
@@ -87,7 +86,7 @@ public class NoSquadScreenTests
         var snapshot = terminal.CreateSnapshot();
         // The key bindings line renders: "C  Create basic squad structure        Q  Quit"
         // Check for the Q key instruction being present
-        snapshot.ContainsText("Quit").Should().BeTrue(
+        Assert.True(snapshot.ContainsText("Quit"),
             "NoSquad screen should show the Q key instruction");
 
         cts.Cancel();
@@ -107,7 +106,7 @@ public class NoSquadScreenTests
         // "Dashboard" in the tab bar would indicate NavBar is showing.
         // However, "Welcome to SquadTUI" confirms we're on NoSquad.
         // We check that pressing 1-6 doesn't navigate away as a resilient assertion.
-        snapshot.ContainsText("Welcome to SquadTUI").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Welcome to SquadTUI"));
 
         // Press D1 — should NOT show Dashboard content (should stay on NoSquad)
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -117,7 +116,7 @@ public class NoSquadScreenTests
         await Task.Delay(200);
 
         var snapshot2 = terminal.CreateSnapshot();
-        snapshot2.ContainsText("Welcome to SquadTUI").Should().BeTrue(
+        Assert.True(snapshot2.ContainsText("Welcome to SquadTUI"),
             "NavBar navigation should not work on NoSquad screen");
 
         cts.Cancel();

--- a/tests/SquadTUI.Tests/E2E/ResponsiveLayoutTests.cs
+++ b/tests/SquadTUI.Tests/E2E/ResponsiveLayoutTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 
@@ -17,12 +16,12 @@ public class ResponsiveLayoutTests
 
         var snapshot = terminal.CreateSnapshot();
         // Narrow layout shows SquadTUI header and Recent/Decisions sections
-        snapshot.ContainsText("SquadTUI").Should().BeTrue();
-        snapshot.ContainsText("Recent").Should().BeTrue();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("SquadTUI"));
+        Assert.True(snapshot.ContainsText("Recent"));
+        Assert.True(snapshot.ContainsText("Decisions"));
         // Wide layout panels should NOT appear
-        snapshot.ContainsText("Team Roster").Should().BeFalse();
-        snapshot.ContainsText("Sprint Metrics").Should().BeFalse();
+        Assert.False(snapshot.ContainsText("Team Roster"));
+        Assert.False(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -38,12 +37,12 @@ public class ResponsiveLayoutTests
 
         var snapshot = terminal.CreateSnapshot();
         // Medium layout shows Dashboard header and Team section
-        snapshot.ContainsText("SquadTUI Dashboard").Should().BeTrue();
-        snapshot.ContainsText("Team").Should().BeTrue();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("SquadTUI Dashboard"));
+        Assert.True(snapshot.ContainsText("Team"));
+        Assert.True(snapshot.ContainsText("Decisions"));
         // Wide layout full titles should NOT appear
-        snapshot.ContainsText("Team Roster").Should().BeFalse();
-        snapshot.ContainsText("Sprint Metrics").Should().BeFalse();
+        Assert.False(snapshot.ContainsText("Team Roster"));
+        Assert.False(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -58,11 +57,11 @@ public class ResponsiveLayoutTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("SquadTUI Dashboard").Should().BeTrue();
-        snapshot.ContainsText("Team").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("SquadTUI Dashboard"));
+        Assert.True(snapshot.ContainsText("Team"));
         // Wide layout titles should NOT appear
-        snapshot.ContainsText("Team Roster").Should().BeFalse();
-        snapshot.ContainsText("Sprint Metrics").Should().BeFalse();
+        Assert.False(snapshot.ContainsText("Team Roster"));
+        Assert.False(snapshot.ContainsText("Sprint Metrics"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -77,9 +76,9 @@ public class ResponsiveLayoutTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
-        snapshot.ContainsText("Activity").Should().BeTrue();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
+        Assert.True(snapshot.ContainsText("Activity"));
+        Assert.True(snapshot.ContainsText("Decisions"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -94,10 +93,10 @@ public class ResponsiveLayoutTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
-        snapshot.ContainsText("Activity").Should().BeTrue();
-        snapshot.ContainsText("Sprint Metrics").Should().BeTrue();
-        snapshot.ContainsText("Velocity:").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
+        Assert.True(snapshot.ContainsText("Activity"));
+        Assert.True(snapshot.ContainsText("Sprint Metrics"));
+        Assert.True(snapshot.ContainsText("Velocity:"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -112,7 +111,7 @@ public class ResponsiveLayoutTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("SquadTUI").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("SquadTUI"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/RosterScreenTests.cs
+++ b/tests/SquadTUI.Tests/E2E/RosterScreenTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -23,9 +22,9 @@ public class RosterScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sonic").Should().BeTrue();
-        snapshot.ContainsText("Tails").Should().BeTrue();
-        snapshot.ContainsText("Knuckles").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sonic"));
+        Assert.True(snapshot.ContainsText("Tails"));
+        Assert.True(snapshot.ContainsText("Knuckles"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -46,9 +45,9 @@ public class RosterScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Sonic").Should().BeTrue();
-        snapshot.ContainsText("Role:").Should().BeTrue();
-        snapshot.ContainsText("Status:").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Sonic"));
+        Assert.True(snapshot.ContainsText("Role:"));
+        Assert.True(snapshot.ContainsText("Status:"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -70,8 +69,8 @@ public class RosterScreenTests
 
         var snapshot = terminal.CreateSnapshot();
         // Detail pane now shows charter excerpt and tasks inline
-        snapshot.ContainsText("Charter").Should().BeTrue();
-        snapshot.ContainsText("Task:").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Charter"));
+        Assert.True(snapshot.ContainsText("Task:"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -94,7 +93,7 @@ public class RosterScreenTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/SettingsNavigationTests.cs
+++ b/tests/SquadTUI.Tests/E2E/SettingsNavigationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -23,7 +22,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Theme Selection").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Theme Selection"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -46,7 +45,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -67,7 +66,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Ocean").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Ocean"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -88,7 +87,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Heist").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Heist"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -109,7 +108,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Navigate").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Navigate"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -130,8 +129,8 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Confirm").Should().BeTrue();
-        snapshot.ContainsText("Cancel").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Confirm"));
+        Assert.True(snapshot.ContainsText("Cancel"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -152,8 +151,8 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Theme Selection").Should().BeTrue();
-        snapshot.ContainsText("Ocean").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Ocean"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -174,7 +173,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Theme Selection").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Theme Selection"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/TabStyleTests.cs
+++ b/tests/SquadTUI.Tests/E2E/TabStyleTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -17,9 +16,9 @@ public class TabStyleTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
-        snapshot.ContainsText("Roster").Should().BeTrue();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
+        Assert.True(snapshot.ContainsText("Roster"));
+        Assert.True(snapshot.ContainsText("Decisions"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -35,7 +34,7 @@ public class TabStyleTests
 
         var snapshot = terminal.CreateSnapshot();
         // The active tab should have the ▶ indicator (ANSI stripped, but text preserved)
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -61,7 +60,7 @@ public class TabStyleTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText(expectedContent).Should().BeTrue();
+        Assert.True(snapshot.ContainsText(expectedContent));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -81,8 +80,8 @@ public class TabStyleTests
 
         var snapshot = terminal.CreateSnapshot();
         // Should not crash and should contain at least Dashboard label
-        snapshot.Should().NotBeNull();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -99,9 +98,9 @@ public class TabStyleTests
 
         var snapshot = terminal.CreateSnapshot();
         // Check for tab labels (ANSI stripped but text preserved)
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
-        snapshot.ContainsText("Roster").Should().BeTrue();
-        snapshot.ContainsText("Decisions").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
+        Assert.True(snapshot.ContainsText("Roster"));
+        Assert.True(snapshot.ContainsText("Decisions"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -124,7 +123,7 @@ public class TabStyleTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/ThemeModalTests.cs
+++ b/tests/SquadTUI.Tests/E2E/ThemeModalTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -23,7 +22,7 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Theme Selection").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Theme Selection"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -44,9 +43,9 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Ocean").Should().BeTrue();
-        snapshot.ContainsText("Heist").Should().BeTrue();
-        snapshot.ContainsText("Sunset").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Ocean"));
+        Assert.True(snapshot.ContainsText("Heist"));
+        Assert.True(snapshot.ContainsText("Sunset"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -69,8 +68,8 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Theme Selection").Should().BeFalse();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.False(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -91,9 +90,9 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Navigate").Should().BeTrue();
-        snapshot.ContainsText("Confirm").Should().BeTrue();
-        snapshot.ContainsText("Cancel").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Navigate"));
+        Assert.True(snapshot.ContainsText("Confirm"));
+        Assert.True(snapshot.ContainsText("Cancel"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -116,8 +115,8 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Theme Selection").Should().BeFalse();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.False(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -139,8 +138,8 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
-        snapshot.ContainsText("Theme Selection").Should().BeFalse();
+        Assert.True(snapshot.ContainsText("Dashboard"));
+        Assert.False(snapshot.ContainsText("Theme Selection"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/ThemeSwitchingTests.cs
+++ b/tests/SquadTUI.Tests/E2E/ThemeSwitchingTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -17,7 +16,7 @@ public class ThemeSwitchingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         // Press T three times to cycle through themes
         for (int i = 0; i < 3; i++)
@@ -31,7 +30,7 @@ public class ThemeSwitchingTests
 
         // App should still render correctly after theme cycling
         var snapshot2 = terminal.CreateSnapshot();
-        snapshot2.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot2.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -46,7 +45,7 @@ public class ThemeSwitchingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         // Press T 4 times to wrap around to initial theme
         for (int i = 0; i < 4; i++)
@@ -59,7 +58,7 @@ public class ThemeSwitchingTests
         }
 
         var finalSnapshot = terminal.CreateSnapshot();
-        finalSnapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(finalSnapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -74,7 +73,7 @@ public class ThemeSwitchingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.T)
@@ -84,8 +83,8 @@ public class ThemeSwitchingTests
 
         // After theme change, nav and content should still render
         var snapshot2 = terminal.CreateSnapshot();
-        snapshot2.ContainsText("Dashboard").Should().BeTrue();
-        snapshot2.ContainsText("Roster").Should().BeTrue();
+        Assert.True(snapshot2.ContainsText("Dashboard"));
+        Assert.True(snapshot2.ContainsText("Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/VimKeybindingTests.cs
+++ b/tests/SquadTUI.Tests/E2E/VimKeybindingTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -26,7 +25,7 @@ public class VimKeybindingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -48,7 +47,7 @@ public class VimKeybindingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Team Roster").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Team Roster"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -72,7 +71,7 @@ public class VimKeybindingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Installed Skills").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Installed Skills"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -95,7 +94,7 @@ public class VimKeybindingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -118,7 +117,7 @@ public class VimKeybindingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -139,7 +138,7 @@ public class VimKeybindingTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        snapshot.ContainsText("Dashboard").Should().BeTrue();
+        Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/EmptyStateTests.cs
+++ b/tests/SquadTUI.Tests/EmptyStateTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using LanguageExt;
 using static LanguageExt.Prelude;
 using SquadTUI.Models;
@@ -15,49 +14,49 @@ public class EmptyStateTests
     public void AppState_EmptyMembers_GetOrEmptyReturnsEmptyList()
     {
         var state = new AppState();
-        state.Members.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Members.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_EmptyDecisions_GetOrEmptyReturnsEmptyList()
     {
         var state = new AppState();
-        state.Decisions.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Decisions.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_EmptySkills_GetOrEmptyReturnsEmptyList()
     {
         var state = new AppState();
-        state.Skills.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Skills.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_EmptyLogEntries_GetOrEmptyReturnsEmptyList()
     {
         var state = new AppState();
-        state.LogEntries.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.LogEntries.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_EmptyTasks_GetOrEmptyReturnsEmptyList()
     {
         var state = new AppState();
-        state.Tasks.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Tasks.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_EmptySprintHistory_GetOrEmptyReturnsEmptyList()
     {
         var state = new AppState();
-        state.SprintHistory.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.SprintHistory.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_CharterContent_NoneByDefault()
     {
         var state = new AppState();
-        state.CharterContent.IsNone.Should().BeTrue();
+        Assert.True(state.CharterContent.IsNone);
     }
 
     [Fact]
@@ -65,7 +64,7 @@ public class EmptyStateTests
     {
         var state = new AppState();
         var charter = state.CharterContent.Match(Some: s => s, None: () => "No charter loaded");
-        charter.Should().Be("No charter loaded");
+        Assert.Equal("No charter loaded", charter);
     }
 
     [Fact]
@@ -76,7 +75,7 @@ public class EmptyStateTests
             CharterContent = Some("# Charter\n\nContent here")
         };
         var charter = state.CharterContent.Match(Some: s => s, None: () => "No charter loaded");
-        charter.Should().Contain("# Charter");
+        Assert.Contains("# Charter", charter);
     }
 
     [Fact]
@@ -84,10 +83,10 @@ public class EmptyStateTests
     {
         var state = new AppState();
         var members = state.Members.GetOrEmpty();
-        members.Should().BeEmpty();
+        Assert.Empty(members);
         // Clamp should produce 0 when count is 0 (list is empty, index stays at 0)
         var idx = Math.Clamp(state.RosterSelectedIndex, 0, Math.Max(0, members.Count - 1));
-        idx.Should().Be(0);
+        Assert.Equal(0, idx);
     }
 
     [Fact]
@@ -95,9 +94,9 @@ public class EmptyStateTests
     {
         var state = new AppState();
         var decisions = state.Decisions.GetOrEmpty();
-        decisions.Should().BeEmpty();
+        Assert.Empty(decisions);
         var idx = Math.Clamp(state.DecisionSelectedIndex, 0, Math.Max(0, decisions.Count - 1));
-        idx.Should().Be(0);
+        Assert.Equal(0, idx);
     }
 
     [Fact]
@@ -105,9 +104,9 @@ public class EmptyStateTests
     {
         var state = new AppState();
         var skills = state.Skills.GetOrEmpty();
-        skills.Should().BeEmpty();
+        Assert.Empty(skills);
         var idx = Math.Clamp(state.SkillSelectedIndex, 0, Math.Max(0, skills.Count - 1));
-        idx.Should().Be(0);
+        Assert.Equal(0, idx);
     }
 
     [Fact]
@@ -115,9 +114,9 @@ public class EmptyStateTests
     {
         var state = new AppState();
         var logs = state.LogEntries.GetOrEmpty();
-        logs.Should().BeEmpty();
+        Assert.Empty(logs);
         var idx = Math.Clamp(state.LogSelectedIndex, 0, Math.Max(0, logs.Count - 1));
-        idx.Should().Be(0);
+        Assert.Equal(0, idx);
     }
 
     [Fact]
@@ -132,8 +131,7 @@ public class EmptyStateTests
         var sprints = state.SprintHistory.GetOrEmpty();
         var tasks = state.Tasks.GetOrEmpty();
         // The MetricsScreen checks: if (sprints.Count == 0 && tasks.Count == 0)
-        (sprints.Count == 0 && tasks.Count == 0).Should().BeTrue(
-            "empty sprint and task data should trigger the 'No sprint data' empty state");
+        Assert.True(sprints.Count == 0 && tasks.Count == 0);
     }
 
     [Fact]
@@ -142,8 +140,7 @@ public class EmptyStateTests
         var state = new AppState();
         var members = state.Members.GetOrEmpty();
         // RosterScreen checks: if (members.Count == 0)
-        members.Count.Should().Be(0,
-            "empty members should trigger the 'No members found' empty state");
+        Assert.Equal(0, members.Count);
     }
 
     [Fact]
@@ -152,8 +149,7 @@ public class EmptyStateTests
         var state = new AppState();
         var decisions = state.Decisions.GetOrEmpty();
         // DecisionsScreen checks: if (decisions.Count == 0)
-        decisions.Count.Should().Be(0,
-            "empty decisions should trigger the 'No decisions found' empty state");
+        Assert.Equal(0, decisions.Count);
     }
 
     [Fact]
@@ -162,8 +158,7 @@ public class EmptyStateTests
         var state = new AppState();
         var logs = state.LogEntries.GetOrEmpty();
         // ActivityLogScreen checks: if (logs.Count == 0)
-        logs.Count.Should().Be(0,
-            "empty log entries should trigger the 'No activity log entries found' empty state");
+        Assert.Equal(0, logs.Count);
     }
 
     [Fact]
@@ -172,8 +167,7 @@ public class EmptyStateTests
         var state = new AppState();
         var skills = state.Skills.GetOrEmpty();
         // SkillsScreen checks: if (skills.Count == 0)
-        skills.Count.Should().Be(0,
-            "empty skills should trigger the 'No skills found' empty state");
+        Assert.Equal(0, skills.Count);
     }
 
     [Fact]
@@ -185,14 +179,14 @@ public class EmptyStateTests
         var logEntries = state.LogEntries.GetOrEmpty();
         var decisions = state.Decisions.GetOrEmpty();
 
-        members.Count.Should().Be(0);
-        tasks.Count.Should().Be(0);
-        logEntries.Count.Should().Be(0);
-        decisions.Count.Should().Be(0);
+        Assert.Equal(0, members.Count);
+        Assert.Equal(0, tasks.Count);
+        Assert.Equal(0, logEntries.Count);
+        Assert.Equal(0, decisions.Count);
 
         // DashboardScreen derives counts via .GetOrEmpty() — zero data = zero counts
         var activeCount = members.Count(m => m.Status == MemberStatus.Active);
-        activeCount.Should().Be(0);
+        Assert.Equal(0, activeCount);
     }
 
     [Fact]
@@ -203,9 +197,9 @@ public class EmptyStateTests
         var completedTasks = tasks.Count(t => t.Status == SquadTaskStatus.Done);
         // DashboardScreen: var total = tasks.Count > 0 ? tasks.Count : 1;
         var total = tasks.Count > 0 ? tasks.Count : 1;
-        total.Should().Be(1, "guard prevents division by zero");
+        Assert.Equal(1, total);
         var percentage = completedTasks * 100 / total;
-        percentage.Should().Be(0);
+        Assert.Equal(0, percentage);
     }
 
     [Fact]
@@ -221,12 +215,12 @@ public class EmptyStateTests
             SprintHistory = Left<AppError, IReadOnlyList<SprintMetrics>>(new ServiceError("M", "fail")),
         };
 
-        state.Members.GetOrEmpty().Should().BeEmpty();
-        state.Decisions.GetOrEmpty().Should().BeEmpty();
-        state.Skills.GetOrEmpty().Should().BeEmpty();
-        state.LogEntries.GetOrEmpty().Should().BeEmpty();
-        state.Tasks.GetOrEmpty().Should().BeEmpty();
-        state.SprintHistory.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Members.GetOrEmpty());
+        Assert.Empty(state.Decisions.GetOrEmpty());
+        Assert.Empty(state.Skills.GetOrEmpty());
+        Assert.Empty(state.LogEntries.GetOrEmpty());
+        Assert.Empty(state.Tasks.GetOrEmpty());
+        Assert.Empty(state.SprintHistory.GetOrEmpty());
     }
 
     [Fact]
@@ -234,11 +228,11 @@ public class EmptyStateTests
     {
         // CharterScreen logic: state.SelectedMemberName ?? (members.Count > 0 ? members[0].Name : "Unknown")
         var state = new AppState();
-        state.SelectedMemberName.Should().BeNull();
+        Assert.Null(state.SelectedMemberName);
 
         var members = state.Members.GetOrEmpty();
         var memberName = state.SelectedMemberName ?? (members.Count > 0 ? members[0].Name : "Unknown");
-        memberName.Should().Be("Unknown", "empty members list defaults to 'Unknown'");
+        Assert.Equal("Unknown", memberName);
     }
 
     [Fact]
@@ -252,10 +246,10 @@ public class EmptyStateTests
                 new("Bob", "Dev", MemberStatus.Active),
             })
         };
-        state.SelectedMemberName.Should().BeNull();
+        Assert.Null(state.SelectedMemberName);
 
         var members = state.Members.GetOrEmpty();
         var memberName = state.SelectedMemberName ?? (members.Count > 0 ? members[0].Name : "Unknown");
-        memberName.Should().Be("Alice", "first member is the default");
+        Assert.Equal("Alice", memberName);
     }
 }

--- a/tests/SquadTUI.Tests/ErrorHandlingTests.cs
+++ b/tests/SquadTUI.Tests/ErrorHandlingTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using LanguageExt;
 using static LanguageExt.Prelude;
 using NSubstitute;
@@ -20,36 +19,36 @@ public class ErrorHandlingTests
     public void FileNotFoundError_HasCorrectMessage()
     {
         var err = new FileNotFoundError("/path/to/file");
-        err.Message.Should().Contain("/path/to/file");
-        err.Path.Should().Be("/path/to/file");
+        Assert.Contains("/path/to/file", err.Message);
+        Assert.Equal("/path/to/file", err.Path);
     }
 
     [Fact]
     public void ParseError_HasCorrectMessage()
     {
         var err = new ParseError("roster.yaml", "invalid yaml");
-        err.Message.Should().Contain("roster.yaml");
-        err.Message.Should().Contain("invalid yaml");
-        err.File.Should().Be("roster.yaml");
-        err.Details.Should().Be("invalid yaml");
+        Assert.Contains("roster.yaml", err.Message);
+        Assert.Contains("invalid yaml", err.Message);
+        Assert.Equal("roster.yaml", err.File);
+        Assert.Equal("invalid yaml", err.Details);
     }
 
     [Fact]
     public void ServiceError_HasCorrectMessage()
     {
         var err = new ServiceError("TeamService", "connection timeout");
-        err.Message.Should().Contain("TeamService");
-        err.Message.Should().Contain("connection timeout");
-        err.Service.Should().Be("TeamService");
-        err.Details.Should().Be("connection timeout");
+        Assert.Contains("TeamService", err.Message);
+        Assert.Contains("connection timeout", err.Message);
+        Assert.Equal("TeamService", err.Service);
+        Assert.Equal("connection timeout", err.Details);
     }
 
     [Fact]
     public void NoDataError_HasCorrectMessage()
     {
         var err = new NoDataError("members");
-        err.Message.Should().Contain("members");
-        err.DataType.Should().Be("members");
+        Assert.Contains("members", err.Message);
+        Assert.Equal("members", err.DataType);
     }
 
     [Fact]
@@ -63,7 +62,7 @@ public class ErrorHandlingTests
             new NoDataError("t"),
         ];
         foreach (var e in errors)
-            e.Should().BeAssignableTo<AppError>();
+            Assert.IsAssignableFrom<AppError>(e);
     }
 
     #endregion
@@ -81,8 +80,8 @@ public class ErrorHandlingTests
             Right<AppError, IReadOnlyList<SquadMember>>(members);
 
         var result = either.GetOrEmpty();
-        result.Should().HaveCount(1);
-        result[0].Name.Should().Be("Alice");
+        Assert.Equal(1, result.Count);
+        Assert.Equal("Alice", result[0].Name);
     }
 
     [Fact]
@@ -92,7 +91,7 @@ public class ErrorHandlingTests
             Left<AppError, IReadOnlyList<SquadMember>>(new ServiceError("Test", "fail"));
 
         var result = either.GetOrEmpty();
-        result.Should().BeEmpty();
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -101,7 +100,7 @@ public class ErrorHandlingTests
         Either<AppError, IReadOnlyList<DecisionEntry>> either =
             Left<AppError, IReadOnlyList<DecisionEntry>>(new NoDataError("decisions"));
 
-        either.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(either.GetOrEmpty());
     }
 
     [Fact]
@@ -111,7 +110,7 @@ public class ErrorHandlingTests
         Either<AppError, IReadOnlyList<Skill>> either =
             Right<AppError, IReadOnlyList<Skill>>(skills);
 
-        either.GetOrEmpty().Should().HaveCount(1);
+        Assert.Equal(1, either.GetOrEmpty().Count);
     }
 
     [Fact]
@@ -120,7 +119,7 @@ public class ErrorHandlingTests
         Either<AppError, IReadOnlyList<SquadTask>> either =
             Left<AppError, IReadOnlyList<SquadTask>>(new FileNotFoundError("tasks.yaml"));
 
-        either.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(either.GetOrEmpty());
     }
 
     [Fact]
@@ -129,7 +128,7 @@ public class ErrorHandlingTests
         Either<AppError, IReadOnlyList<OrchestrationLogEntry>> either =
             Left<AppError, IReadOnlyList<OrchestrationLogEntry>>(new ParseError("log.md", "bad format"));
 
-        either.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(either.GetOrEmpty());
     }
 
     [Fact]
@@ -138,7 +137,7 @@ public class ErrorHandlingTests
         Either<AppError, IReadOnlyList<SprintMetrics>> either =
             Left<AppError, IReadOnlyList<SprintMetrics>>(new NoDataError("sprints"));
 
-        either.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(either.GetOrEmpty());
     }
 
     #endregion
@@ -156,13 +155,13 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
-        result.IsLeft.Should().BeTrue("DataBridge should return Left on service exception");
+        Assert.True(result.IsLeft);
         result.Match(
             Right: _ => throw new Exception("Should be Left"),
             Left: err =>
             {
-                err.Should().BeOfType<ServiceError>();
-                err.Message.Should().Contain("disk error");
+                Assert.IsType<ServiceError>(err);
+                Assert.Contains("disk error", err.Message);
             });
     }
 
@@ -180,10 +179,10 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
-        result.IsRight.Should().BeTrue();
+        Assert.True(result.IsRight);
         var data = result.GetOrEmpty();
-        data.Should().HaveCount(1);
-        data[0].Name.Should().Be("Alice");
+        Assert.Equal(1, data.Count);
+        Assert.Equal("Alice", data[0].Name);
     }
 
     [Fact]
@@ -197,7 +196,7 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadDecisionsDataAsync();
-        result.IsLeft.Should().BeTrue();
+        Assert.True(result.IsLeft);
     }
 
     [Fact]
@@ -214,8 +213,8 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadDecisionsDataAsync();
-        result.IsRight.Should().BeTrue();
-        result.GetOrEmpty().Should().HaveCount(1);
+        Assert.True(result.IsRight);
+        Assert.Equal(1, result.GetOrEmpty().Count);
     }
 
     [Fact]
@@ -229,7 +228,7 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadSkillsDataAsync();
-        result.IsLeft.Should().BeTrue();
+        Assert.True(result.IsLeft);
     }
 
     [Fact]
@@ -243,7 +242,7 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadLogDataAsync();
-        result.IsLeft.Should().BeTrue();
+        Assert.True(result.IsLeft);
     }
 
     [Fact]
@@ -257,7 +256,7 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadTasksFromRosterAsync();
-        result.IsLeft.Should().BeTrue();
+        Assert.True(result.IsLeft);
     }
 
     [Fact]
@@ -278,14 +277,14 @@ public class ErrorHandlingTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadTasksFromRosterAsync();
-        result.IsRight.Should().BeTrue();
+        Assert.True(result.IsRight);
         var tasks = result.GetOrEmpty();
-        tasks.Should().HaveCount(4, "member E has no CurrentTask and should be skipped");
+        Assert.Equal(4, tasks.Count);
 
-        tasks[0].Status.Should().Be(SquadTaskStatus.InProgress, "Working → InProgress");
-        tasks[1].Status.Should().Be(SquadTaskStatus.InProgress, "Active → InProgress");
-        tasks[2].Status.Should().Be(SquadTaskStatus.Pending, "Idle → Pending");
-        tasks[3].Status.Should().Be(SquadTaskStatus.Pending, "Offline → Pending");
+        Assert.Equal(SquadTaskStatus.InProgress, tasks[0].Status);
+        Assert.Equal(SquadTaskStatus.InProgress, tasks[1].Status);
+        Assert.Equal(SquadTaskStatus.Pending, tasks[2].Status);
+        Assert.Equal(SquadTaskStatus.Pending, tasks[3].Status);
     }
 
     #endregion
@@ -299,7 +298,7 @@ public class ErrorHandlingTests
         {
             Members = Left<AppError, IReadOnlyList<SquadMember>>(new ServiceError("Roster", "fail")),
         };
-        state.Members.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Members.GetOrEmpty());
     }
 
     [Fact]
@@ -309,7 +308,7 @@ public class ErrorHandlingTests
         {
             Decisions = Left<AppError, IReadOnlyList<DecisionEntry>>(new NoDataError("decisions")),
         };
-        state.Decisions.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Decisions.GetOrEmpty());
     }
 
     [Fact]
@@ -319,33 +318,33 @@ public class ErrorHandlingTests
         {
             Tasks = Left<AppError, IReadOnlyList<SquadTask>>(new FileNotFoundError("tasks.yaml")),
         };
-        state.Tasks.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Tasks.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_DefaultState_AllEithersAreRightEmpty()
     {
         var state = new AppState();
-        state.Members.IsRight.Should().BeTrue();
-        state.Decisions.IsRight.Should().BeTrue();
-        state.Skills.IsRight.Should().BeTrue();
-        state.LogEntries.IsRight.Should().BeTrue();
-        state.Tasks.IsRight.Should().BeTrue();
-        state.SprintHistory.IsRight.Should().BeTrue();
+        Assert.True(state.Members.IsRight);
+        Assert.True(state.Decisions.IsRight);
+        Assert.True(state.Skills.IsRight);
+        Assert.True(state.LogEntries.IsRight);
+        Assert.True(state.Tasks.IsRight);
+        Assert.True(state.SprintHistory.IsRight);
 
-        state.Members.GetOrEmpty().Should().BeEmpty();
-        state.Decisions.GetOrEmpty().Should().BeEmpty();
-        state.Skills.GetOrEmpty().Should().BeEmpty();
-        state.LogEntries.GetOrEmpty().Should().BeEmpty();
-        state.Tasks.GetOrEmpty().Should().BeEmpty();
-        state.SprintHistory.GetOrEmpty().Should().BeEmpty();
+        Assert.Empty(state.Members.GetOrEmpty());
+        Assert.Empty(state.Decisions.GetOrEmpty());
+        Assert.Empty(state.Skills.GetOrEmpty());
+        Assert.Empty(state.LogEntries.GetOrEmpty());
+        Assert.Empty(state.Tasks.GetOrEmpty());
+        Assert.Empty(state.SprintHistory.GetOrEmpty());
     }
 
     [Fact]
     public void AppState_CharterContent_DefaultsToNone()
     {
         var state = new AppState();
-        state.CharterContent.IsNone.Should().BeTrue();
+        Assert.True(state.CharterContent.IsNone);
     }
 
     #endregion

--- a/tests/SquadTUI.Tests/Integration/CIPipelineTests.cs
+++ b/tests/SquadTUI.Tests/Integration/CIPipelineTests.cs
@@ -1,5 +1,3 @@
-using FluentAssertions;
-
 namespace SquadTUI.Tests.Integration;
 
 public class CIPipelineTests
@@ -22,7 +20,7 @@ public class CIPipelineTests
     public void GitHubWorkflowsDirectory_Exists()
     {
         var workflowsDir = Path.Combine(_repoRoot, ".github", "workflows");
-        Directory.Exists(workflowsDir).Should().BeTrue("GitHub Actions workflows directory should exist");
+        Assert.True(Directory.Exists(workflowsDir));
     }
 
     [Fact]
@@ -32,7 +30,7 @@ public class CIPipelineTests
         var ciYamlAlternate = Path.Combine(_repoRoot, ".github", "workflows", "ci.yaml");
 
         var exists = File.Exists(ciYaml) || File.Exists(ciYamlAlternate);
-        exists.Should().BeTrue("CI workflow YAML file should exist");
+        Assert.True(exists);
     }
 
     [Fact]
@@ -46,17 +44,17 @@ public class CIPipelineTests
             .Concat(Directory.GetFiles(workflowsDir, "*.yaml"))
             .ToList();
 
-        yamlFiles.Should().NotBeEmpty("should have at least one workflow YAML file");
+        Assert.NotEmpty(yamlFiles);
 
         foreach (var yamlFile in yamlFiles)
         {
             var content = File.ReadAllText(yamlFile);
             
             // Basic YAML validation - should have key workflow properties
-            content.Should().NotBeNullOrEmpty();
-            content.Should().Contain("name:", "workflow should have a name");
-            content.Should().Contain("on:", "workflow should have triggers");
-            content.Should().Contain("jobs:", "workflow should have jobs");
+            Assert.False(string.IsNullOrEmpty(content));
+            Assert.Contains("name:", content);
+            Assert.Contains("on:", content);
+            Assert.Contains("jobs:", content);
         }
     }
 
@@ -82,7 +80,7 @@ public class CIPipelineTests
             }
         }
 
-        hasBuildStep.Should().BeTrue("CI workflow should contain a build step");
+        Assert.True(hasBuildStep);
     }
 
     [Fact]
@@ -107,21 +105,21 @@ public class CIPipelineTests
             }
         }
 
-        hasTestStep.Should().BeTrue("CI workflow should contain a test step");
+        Assert.True(hasTestStep);
     }
 
     [Fact]
     public void ProjectFile_Exists()
     {
         var projectFile = Path.Combine(_repoRoot, "src", "SquadTUI", "SquadTUI.csproj");
-        File.Exists(projectFile).Should().BeTrue("main project file should exist");
+        Assert.True(File.Exists(projectFile));
     }
 
     [Fact]
     public void TestProjectFile_Exists()
     {
         var testProjectFile = Path.Combine(_repoRoot, "tests", "SquadTUI.Tests", "SquadTUI.Tests.csproj");
-        File.Exists(testProjectFile).Should().BeTrue("test project file should exist");
+        Assert.True(File.Exists(testProjectFile));
     }
 
     [Fact]
@@ -131,7 +129,7 @@ public class CIPipelineTests
             .Concat(Directory.GetFiles(_repoRoot, "*.slnx"))
             .ToList();
 
-        slnFiles.Should().NotBeEmpty("solution file should exist");
+        Assert.NotEmpty(slnFiles);
     }
 
     // DotnetBuild_Succeeds and DotnetTest_Passes were removed.

--- a/tests/SquadTUI.Tests/Integration/DecisionServiceIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/DecisionServiceIntegrationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Integration;
@@ -15,7 +14,7 @@ public class DecisionServiceIntegrationTests
         var decisions = await svc.GetDecisionsAsync();
 
         // 3 from decisions.md + 1 from inbox
-        decisions.Should().HaveCount(4);
+        Assert.Equal(4, decisions.Count);
     }
 
     [Fact]
@@ -25,9 +24,9 @@ public class DecisionServiceIntegrationTests
         var decisions = await svc.GetDecisionsAsync();
 
         var titles = decisions.Select(d => d.Title).ToList();
-        titles.Should().Contain("Project Architecture");
-        titles.Should().Contain("UX Design");
-        titles.Should().Contain("Testing Strategy");
+        Assert.Contains("Project Architecture", titles);
+        Assert.Contains("UX Design", titles);
+        Assert.Contains("Testing Strategy", titles);
     }
 
     [Fact]
@@ -37,8 +36,8 @@ public class DecisionServiceIntegrationTests
         var decisions = await svc.GetDecisionsAsync();
 
         var arch = decisions.First(d => d.Title == "Project Architecture");
-        arch.Author.Should().Be("Danny");
-        arch.Date.Should().Be("2026-02-16");
+        Assert.Equal("Danny", arch.Author);
+        Assert.Equal("2026-02-16", arch.Date);
     }
 
     [Fact]
@@ -48,7 +47,7 @@ public class DecisionServiceIntegrationTests
         var decisions = await svc.GetDecisionsAsync();
 
         var inbox = decisions.First(d => d.Title == "Data Layer Design");
-        inbox.Author.Should().Be("Rusty");
-        inbox.Content.Should().Contain("File-based data providers");
+        Assert.Equal("Rusty", inbox.Author);
+        Assert.Contains("File-based data providers", inbox.Content);
     }
 }

--- a/tests/SquadTUI.Tests/Integration/OrchestrationLogServiceIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/OrchestrationLogServiceIntegrationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Integration;
@@ -14,7 +13,7 @@ public class OrchestrationLogServiceIntegrationTests
         var svc = new OrchestrationLogService(GetFixturesPath());
         var entries = await svc.GetEntriesAsync();
 
-        entries.Should().NotBeEmpty();
+        Assert.NotEmpty(entries);
     }
 
     [Fact]
@@ -24,7 +23,7 @@ public class OrchestrationLogServiceIntegrationTests
         var entries = await svc.GetEntriesAsync();
 
         var kickoff = entries.First(e => e.Topic == "kickoff");
-        kickoff.Date.Should().Be("2026-02-16");
+        Assert.Equal("2026-02-16", kickoff.Date);
     }
 
     [Fact]
@@ -34,7 +33,9 @@ public class OrchestrationLogServiceIntegrationTests
         var entries = await svc.GetEntriesAsync();
 
         var kickoff = entries.First(e => e.Topic == "kickoff");
-        kickoff.Participants.Should().Contain(["Danny", "Linus", "Rusty"]);
+        Assert.Contains("Danny", kickoff.Participants);
+        Assert.Contains("Linus", kickoff.Participants);
+        Assert.Contains("Rusty", kickoff.Participants);
     }
 
     [Fact]
@@ -44,7 +45,7 @@ public class OrchestrationLogServiceIntegrationTests
         var entries = await svc.GetEntriesAsync();
 
         var kickoff = entries.First(e => e.Topic == "kickoff");
-        kickoff.Decisions.Should().Contain("Use Hex1b framework");
+        Assert.Contains("Use Hex1b framework", kickoff.Decisions);
     }
 
     [Fact]
@@ -54,6 +55,6 @@ public class OrchestrationLogServiceIntegrationTests
         var entries = await svc.GetEntriesAsync();
 
         var kickoff = entries.First(e => e.Topic == "kickoff");
-        kickoff.Outcomes.Should().Contain("Repository initialized");
+        Assert.Contains("Repository initialized", kickoff.Outcomes);
     }
 }

--- a/tests/SquadTUI.Tests/Integration/SkillServiceIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/SkillServiceIntegrationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Integration;
@@ -14,7 +13,7 @@ public class SkillServiceIntegrationTests
         var svc = new SkillService(GetFixturesPath());
         var skills = await svc.GetSkillsAsync();
 
-        skills.Should().ContainSingle();
+        Assert.Single(skills);
     }
 
     [Fact]
@@ -24,11 +23,11 @@ public class SkillServiceIntegrationTests
         var skills = await svc.GetSkillsAsync();
 
         var skill = skills.First();
-        skill.Name.Should().Be("test-skill");
-        skill.Description.Should().Be("A skill for testing purposes");
-        skill.Source.Should().Be("manual");
-        skill.Confidence.Should().Be("high");
-        skill.Slug.Should().Be("test-skill");
+        Assert.Equal("test-skill", skill.Name);
+        Assert.Equal("A skill for testing purposes", skill.Description);
+        Assert.Equal("manual", skill.Source);
+        Assert.Equal("high", skill.Confidence);
+        Assert.Equal("test-skill", skill.Slug);
     }
 
     [Fact]
@@ -37,7 +36,7 @@ public class SkillServiceIntegrationTests
         var svc = new SkillService(GetFixturesPath());
         var skills = await svc.GetSkillsAsync();
 
-        skills.First().Content.Should().Contain("integration tests");
+        Assert.Contains("integration tests", skills.First().Content);
     }
 
     [Fact]
@@ -46,8 +45,8 @@ public class SkillServiceIntegrationTests
         var svc = new SkillService(GetFixturesPath());
         var skill = await svc.GetSkillAsync("test-skill");
 
-        skill.Should().NotBeNull();
-        skill!.Name.Should().Be("test-skill");
+        Assert.NotNull(skill);
+        Assert.Equal("test-skill", skill!.Name);
     }
 
     [Fact]
@@ -56,6 +55,6 @@ public class SkillServiceIntegrationTests
         var svc = new SkillService(GetFixturesPath());
         var skill = await svc.GetSkillAsync("nonexistent");
 
-        skill.Should().BeNull();
+        Assert.Null(skill);
     }
 }

--- a/tests/SquadTUI.Tests/Integration/SquadDataProviderIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/SquadDataProviderIntegrationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Integration;
@@ -20,9 +19,9 @@ public class SquadDataProviderIntegrationTests
 
         var dashboard = await provider.GetDashboardAsync();
 
-        dashboard.Team.Should().NotBeNull();
-        dashboard.Team.TotalMembers.Should().BeGreaterThan(0);
-        dashboard.Decisions.Should().NotBeEmpty();
+        Assert.NotNull(dashboard.Team);
+        Assert.True(dashboard.Team.TotalMembers > 0);
+        Assert.NotEmpty(dashboard.Decisions);
     }
 
     [Fact]
@@ -37,8 +36,8 @@ public class SquadDataProviderIntegrationTests
 
         var roster = await provider.GetRosterAsync();
 
-        roster.Members.Should().NotBeNull();
-        roster.Members!.Select(m => m.Name).Should().Contain("Danny");
+        Assert.NotNull(roster.Members);
+        Assert.Contains("Danny", roster.Members!.Select(m => m.Name));
     }
 
     [Fact]
@@ -54,8 +53,8 @@ public class SquadDataProviderIntegrationTests
         var dashboard = await provider.GetDashboardAsync();
 
         // Active + Working members
-        dashboard.Team.ActiveMembers.Should().BeGreaterThan(0);
-        dashboard.Team.ActiveMembers.Should().BeLessThanOrEqualTo(dashboard.Team.TotalMembers);
+        Assert.True(dashboard.Team.ActiveMembers > 0);
+        Assert.True(dashboard.Team.ActiveMembers <= dashboard.Team.TotalMembers);
     }
 
     [Fact]
@@ -70,7 +69,7 @@ public class SquadDataProviderIntegrationTests
 
         var skills = await provider.GetSkillsAsync();
 
-        skills.Should().NotBeEmpty();
+        Assert.NotEmpty(skills);
     }
 
     [Fact]
@@ -85,6 +84,6 @@ public class SquadDataProviderIntegrationTests
 
         var logs = await provider.GetLogEntriesAsync();
 
-        logs.Should().NotBeEmpty();
+        Assert.NotEmpty(logs);
     }
 }

--- a/tests/SquadTUI.Tests/Integration/TeamServiceIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/TeamServiceIntegrationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Models;
 using SquadTUI.Services;
 
@@ -15,16 +14,16 @@ public class TeamServiceIntegrationTests
         var svc = new TeamService(GetFixturesPath());
         var roster = await svc.GetRosterAsync();
 
-        roster.Members.Should().NotBeNull();
+        Assert.NotNull(roster.Members);
         // 5 members + 1 coordinator = 6
-        roster.Members!.Count.Should().BeGreaterThanOrEqualTo(5);
+        Assert.True(roster.Members!.Count >= 5);
 
         var names = roster.Members.Select(m => m.Name).ToList();
-        names.Should().Contain("Danny");
-        names.Should().Contain("Linus");
-        names.Should().Contain("Rusty");
-        names.Should().Contain("Basher");
-        names.Should().Contain("Saul");
+        Assert.Contains("Danny", names);
+        Assert.Contains("Linus", names);
+        Assert.Contains("Rusty", names);
+        Assert.Contains("Basher", names);
+        Assert.Contains("Saul", names);
     }
 
     [Fact]
@@ -33,8 +32,8 @@ public class TeamServiceIntegrationTests
         var svc = new TeamService(GetFixturesPath());
         var roster = await svc.GetRosterAsync();
 
-        roster.Members!.First().Name.Should().Be("Squad");
-        roster.Members!.First().Role.Should().Be("Coordinator");
+        Assert.Equal("Squad", roster.Members!.First().Name);
+        Assert.Equal("Coordinator", roster.Members!.First().Role);
     }
 
     [Fact]
@@ -44,13 +43,13 @@ public class TeamServiceIntegrationTests
         var roster = await svc.GetRosterAsync();
 
         var danny = roster.Members!.First(m => m.Name == "Danny");
-        danny.Status.Should().Be(MemberStatus.Active);
+        Assert.Equal(MemberStatus.Active, danny.Status);
 
         var rusty = roster.Members!.First(m => m.Name == "Rusty");
-        rusty.Status.Should().Be(MemberStatus.Working);
+        Assert.Equal(MemberStatus.Working, rusty.Status);
 
         var saul = roster.Members!.First(m => m.Name == "Saul");
-        saul.Status.Should().Be(MemberStatus.Idle);
+        Assert.Equal(MemberStatus.Idle, saul.Status);
     }
 
     [Fact]
@@ -59,8 +58,8 @@ public class TeamServiceIntegrationTests
         var svc = new TeamService(GetFixturesPath());
         var roster = await svc.GetRosterAsync();
 
-        roster.Description.Should().NotBeNullOrEmpty();
-        roster.Description.Should().Contain("AI squads");
+        Assert.False(string.IsNullOrEmpty(roster.Description));
+        Assert.Contains("AI squads", roster.Description);
     }
 
     [Fact]
@@ -70,8 +69,8 @@ public class TeamServiceIntegrationTests
         var roster = await svc.GetRosterAsync();
 
         var danny = roster.Members!.First(m => m.Name == "Danny");
-        danny.CharterPath.Should().NotBeNull();
-        File.Exists(danny.CharterPath).Should().BeTrue();
+        Assert.NotNull(danny.CharterPath);
+        Assert.True(File.Exists(danny.CharterPath));
     }
 
     [Fact]
@@ -80,7 +79,7 @@ public class TeamServiceIntegrationTests
         var svc = new TeamService(GetFixturesPath());
         var member = await svc.GetMemberAsync("Danny");
 
-        member.Should().NotBeNull();
-        member!.Role.Should().Be("Lead");
+        Assert.NotNull(member);
+        Assert.Equal("Lead", member!.Role);
     }
 }

--- a/tests/SquadTUI.Tests/Integration/ThemeIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/ThemeIntegrationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Screens;
 using SquadTUI.Themes;
 using SquadTUI.Tests.Fixtures;
@@ -11,7 +10,7 @@ public class ThemeIntegrationTests
     public void AppState_DefaultThemeIndex_IsZero()
     {
         var state = new AppState();
-        state.SelectedThemeIndex.Should().Be(0);
+        Assert.Equal(0, state.SelectedThemeIndex);
     }
 
     [Fact]
@@ -22,7 +21,7 @@ public class ThemeIntegrationTests
         {
             state.SelectedThemeIndex = (state.SelectedThemeIndex + 1) % ThemeManager.ThemeNames.Length;
         }
-        state.SelectedThemeIndex.Should().Be(1);
+        Assert.Equal(1, state.SelectedThemeIndex);
     }
 
     [Fact]
@@ -31,40 +30,40 @@ public class ThemeIntegrationTests
         for (int i = 0; i < ThemeManager.ThemeNames.Length; i++)
         {
             var theme = ThemeManager.GetTheme(i);
-            theme.Should().NotBeNull($"theme at index {i} ({ThemeManager.ThemeNames[i]}) should be creatable");
+            Assert.NotNull(theme);
         }
     }
 
     [Fact]
     public void SampleData_IsAvailable()
     {
-        SampleData.Members.Should().NotBeEmpty();
-        SampleData.Tasks.Should().NotBeEmpty();
-        SampleData.Decisions.Should().NotBeEmpty();
-        SampleData.Skills.Should().NotBeEmpty();
-        SampleData.LogEntries.Should().NotBeEmpty();
+        Assert.NotEmpty(SampleData.Members);
+        Assert.NotEmpty(SampleData.Tasks);
+        Assert.NotEmpty(SampleData.Decisions);
+        Assert.NotEmpty(SampleData.Skills);
+        Assert.NotEmpty(SampleData.LogEntries);
     }
 
     [Fact]
     public void AppState_ScreenNavigation_Works()
     {
         var state = new AppState();
-        state.CurrentScreen.Should().Be(Screen.Dashboard);
+        Assert.Equal(Screen.Dashboard, state.CurrentScreen);
 
         state.CurrentScreen = Screen.Roster;
-        state.CurrentScreen.Should().Be(Screen.Roster);
+        Assert.Equal(Screen.Roster, state.CurrentScreen);
 
         state.CurrentScreen = Screen.Decisions;
-        state.CurrentScreen.Should().Be(Screen.Decisions);
+        Assert.Equal(Screen.Decisions, state.CurrentScreen);
     }
 
     [Fact]
     public void AppState_MemberSelection_Works()
     {
         var state = new AppState();
-        state.SelectedMemberName.Should().BeNull();
+        Assert.Null(state.SelectedMemberName);
 
         state.SelectedMemberName = "Sonic";
-        state.SelectedMemberName.Should().Be("Sonic");
+        Assert.Equal("Sonic", state.SelectedMemberName);
     }
 }

--- a/tests/SquadTUI.Tests/IntegrationTests.cs
+++ b/tests/SquadTUI.Tests/IntegrationTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using LanguageExt;
 using static LanguageExt.Prelude;
 using NSubstitute;
@@ -45,11 +44,11 @@ public class IntegrationTests
         var logs = await bridge.LoadLogDataAsync();
         var tasks = await bridge.LoadTasksFromRosterAsync();
 
-        roster.IsLeft.Should().BeTrue();
-        decisions.IsLeft.Should().BeTrue();
-        skills.IsLeft.Should().BeTrue();
-        logs.IsLeft.Should().BeTrue();
-        tasks.IsLeft.Should().BeTrue();
+        Assert.True(roster.IsLeft);
+        Assert.True(decisions.IsLeft);
+        Assert.True(skills.IsLeft);
+        Assert.True(logs.IsLeft);
+        Assert.True(tasks.IsLeft);
     }
 
     [Fact]
@@ -69,9 +68,9 @@ public class IntegrationTests
         var roster = await bridge.LoadRosterDataAsync();
         var decisions = await bridge.LoadDecisionsDataAsync();
 
-        roster.IsLeft.Should().BeTrue("team service failed");
-        decisions.IsRight.Should().BeTrue("decision service succeeded");
-        decisions.GetOrEmpty().Should().HaveCount(1);
+        Assert.True(roster.IsLeft);
+        Assert.True(decisions.IsRight);
+        Assert.Equal(1, decisions.GetOrEmpty().Count);
     }
 
     [Fact]
@@ -85,7 +84,7 @@ public class IntegrationTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadCharterContentAsync("nobody");
-        result.IsNone.Should().BeTrue();
+        Assert.True(result.IsNone);
     }
 
     [Fact]
@@ -99,7 +98,7 @@ public class IntegrationTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadCharterContentAsync("crash");
-        result.IsNone.Should().BeTrue("exception should be caught and return None");
+        Assert.True(result.IsNone);
     }
 
     [Fact]
@@ -113,8 +112,8 @@ public class IntegrationTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
-        result.IsRight.Should().BeTrue();
-        result.GetOrEmpty().Should().BeEmpty();
+        Assert.True(result.IsRight);
+        Assert.Empty(result.GetOrEmpty());
     }
 
     [Fact]
@@ -128,8 +127,8 @@ public class IntegrationTests
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
-        result.IsRight.Should().BeTrue();
-        result.GetOrEmpty().Should().BeEmpty("null Members should become empty list");
+        Assert.True(result.IsRight);
+        Assert.Empty(result.GetOrEmpty());
     }
 
     #endregion
@@ -155,9 +154,9 @@ public class IntegrationTests
             }),
         };
 
-        state.Members.GetOrEmpty().Should().HaveCount(1);
-        state.Tasks.GetOrEmpty().Should().HaveCount(1);
-        state.Decisions.GetOrEmpty().Should().HaveCount(1);
+        Assert.Equal(1, state.Members.GetOrEmpty().Count);
+        Assert.Equal(1, state.Tasks.GetOrEmpty().Count);
+        Assert.Equal(1, state.Decisions.GetOrEmpty().Count);
     }
 
     [Fact]
@@ -170,9 +169,9 @@ public class IntegrationTests
             Decisions = Left<AppError, IReadOnlyList<DecisionEntry>>(new NoDataError("decisions")),
         };
 
-        state.Members.IsLeft.Should().BeTrue();
-        state.Tasks.IsLeft.Should().BeTrue();
-        state.Decisions.IsLeft.Should().BeTrue();
+        Assert.True(state.Members.IsLeft);
+        Assert.True(state.Tasks.IsLeft);
+        Assert.True(state.Decisions.IsLeft);
     }
 
     [Fact]
@@ -187,10 +186,10 @@ public class IntegrationTests
             Tasks = Left<AppError, IReadOnlyList<SquadTask>>(new ServiceError("Tasks", "timeout")),
         };
 
-        state.Members.IsRight.Should().BeTrue();
-        state.Members.GetOrEmpty().Should().HaveCount(1);
-        state.Tasks.IsLeft.Should().BeTrue();
-        state.Tasks.GetOrEmpty().Should().BeEmpty();
+        Assert.True(state.Members.IsRight);
+        Assert.Equal(1, state.Members.GetOrEmpty().Count);
+        Assert.True(state.Tasks.IsLeft);
+        Assert.Empty(state.Tasks.GetOrEmpty());
     }
 
     #endregion
@@ -201,7 +200,7 @@ public class IntegrationTests
     public void AppSettings_DefaultThemeName_IsOcean()
     {
         var settings = new AppSettings();
-        settings.ThemeName.Should().Be("Ocean");
+        Assert.Equal("Ocean", settings.ThemeName);
     }
 
     [Theory]
@@ -217,7 +216,7 @@ public class IntegrationTests
     [InlineData(9, "Retro")]
     public void ThemeIndex_MapsToThemeName(int index, string expectedName)
     {
-        ThemeManager.ThemeNames[index].Should().Be(expectedName);
+        Assert.Equal(expectedName, ThemeManager.ThemeNames[index]);
     }
 
     [Fact]
@@ -227,7 +226,7 @@ public class IntegrationTests
         for (int i = 0; i < 10; i++)
         {
             state.SelectedThemeIndex = i;
-            ThemeManager.ThemeNames[state.SelectedThemeIndex].Should().NotBeNullOrEmpty();
+            Assert.False(string.IsNullOrEmpty(ThemeManager.ThemeNames[state.SelectedThemeIndex]));
         }
     }
 
@@ -238,7 +237,7 @@ public class IntegrationTests
         foreach (var name in ThemeManager.ThemeNames)
         {
             settings.ThemeName = name;
-            settings.ThemeName.Should().Be(name);
+            Assert.Equal(name, settings.ThemeName);
         }
     }
 
@@ -249,8 +248,8 @@ public class IntegrationTests
         var json = System.Text.Json.JsonSerializer.Serialize(settings);
         var deserialized = System.Text.Json.JsonSerializer.Deserialize<AppSettings>(json);
 
-        deserialized.Should().NotBeNull();
-        deserialized!.ThemeName.Should().Be("Cyberpunk");
+        Assert.NotNull(deserialized);
+        Assert.Equal("Cyberpunk", deserialized!.ThemeName);
     }
 
     [Fact]
@@ -268,13 +267,13 @@ public class IntegrationTests
         var json = System.Text.Json.JsonSerializer.Serialize(settings);
         var deserialized = System.Text.Json.JsonSerializer.Deserialize<AppSettings>(json);
 
-        deserialized.Should().NotBeNull();
-        deserialized!.ThemeName.Should().Be("Retro");
-        deserialized.VimBindings.Should().BeFalse();
-        deserialized.MouseEnabled.Should().BeFalse();
-        deserialized.ShowEmoji.Should().BeFalse();
-        deserialized.MarkdownRendering.Should().BeFalse();
-        deserialized.DefaultScreen.Should().Be("Roster");
+        Assert.NotNull(deserialized);
+        Assert.Equal("Retro", deserialized!.ThemeName);
+        Assert.False(deserialized.VimBindings);
+        Assert.False(deserialized.MouseEnabled);
+        Assert.False(deserialized.ShowEmoji);
+        Assert.False(deserialized.MarkdownRendering);
+        Assert.Equal("Roster", deserialized.DefaultScreen);
     }
 
     [Fact]
@@ -282,7 +281,7 @@ public class IntegrationTests
     {
         var corrupt = "{ invalid json @@@ }";
         var act = () => System.Text.Json.JsonSerializer.Deserialize<AppSettings>(corrupt);
-        act.Should().Throw<System.Text.Json.JsonException>();
+        Assert.Throws<System.Text.Json.JsonException>(act);
     }
 
     #endregion

--- a/tests/SquadTUI.Tests/SampleDataLeakTests.cs
+++ b/tests/SquadTUI.Tests/SampleDataLeakTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using LanguageExt;
 using static LanguageExt.Prelude;
 using SquadTUI.Models;
@@ -20,8 +19,7 @@ public class SampleDataLeakTests
     {
         var srcDir = FindSrcDir();
         var sampleFiles = Directory.GetFiles(srcDir, "SampleData.cs", SearchOption.AllDirectories);
-        sampleFiles.Should().BeEmpty(
-            "SampleData.cs must not exist in the production project (src/SquadTUI/)");
+        Assert.Empty(sampleFiles);
     }
 
     [Fact]
@@ -38,9 +36,7 @@ public class SampleDataLeakTests
                 violations.Add(Path.GetFileName(file));
         }
 
-        violations.Should().BeEmpty(
-            "no .cs file in src/SquadTUI/ should reference SampleData — " +
-            $"found in: {string.Join(", ", violations)}");
+        Assert.Empty(violations);
     }
 
     [Fact]
@@ -48,11 +44,10 @@ public class SampleDataLeakTests
     {
         var srcDir = FindSrcDir();
         var csproj = Directory.GetFiles(srcDir, "*.csproj", SearchOption.TopDirectoryOnly);
-        csproj.Should().NotBeEmpty("SquadTUI.csproj should exist");
+        Assert.NotEmpty(csproj);
 
         var content = File.ReadAllText(csproj[0]);
-        content.Should().NotContain("SampleData",
-            "the production .csproj must not reference SampleData");
+        Assert.DoesNotContain("SampleData", content);
     }
 
     [Fact]
@@ -63,8 +58,7 @@ public class SampleDataLeakTests
 
         foreach (var sampleName in SampleDataNames)
         {
-            memberNames.Should().NotContain(sampleName,
-                $"production AppState should not contain SampleData member name '{sampleName}'");
+            Assert.DoesNotContain(sampleName, memberNames);
         }
     }
 
@@ -79,8 +73,7 @@ public class SampleDataLeakTests
 
         foreach (var sampleName in SampleDataNames)
         {
-            assignees.Should().NotContain(sampleName,
-                $"production AppState tasks should not have SampleData assignee '{sampleName}'");
+            Assert.DoesNotContain(sampleName, assignees);
         }
     }
 
@@ -92,8 +85,7 @@ public class SampleDataLeakTests
 
         foreach (var sampleName in SampleDataNames)
         {
-            authors.Should().NotContain(sampleName,
-                $"production AppState decisions should not have SampleData author '{sampleName}'");
+            Assert.DoesNotContain(sampleName, authors);
         }
     }
 
@@ -102,8 +94,7 @@ public class SampleDataLeakTests
     {
         var testDir = FindTestDir();
         var fixtureFile = Path.Combine(testDir, "Fixtures", "SampleData.cs");
-        File.Exists(fixtureFile).Should().BeTrue(
-            "SampleData.cs should exist in tests/SquadTUI.Tests/Fixtures/");
+        Assert.True(File.Exists(fixtureFile));
     }
 
     private static AppState CreateStateWithRealData()

--- a/tests/SquadTUI.Tests/SquadTUI.Tests.csproj
+++ b/tests/SquadTUI.Tests/SquadTUI.Tests.csproj
@@ -8,14 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Hex1b" Version="0.87.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Hex1b" Version="0.90.0" />
     <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SquadTUI.Tests/ThemeCoverageTests.cs
+++ b/tests/SquadTUI.Tests/ThemeCoverageTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using LanguageExt;
 using static LanguageExt.Prelude;
 using SquadTUI.Models;
@@ -25,7 +24,7 @@ public class ThemeCoverageTests
     [InlineData(9)]
     public void GetAccentCode_IsNonEmpty_ForAllThemes(int index)
     {
-        ThemeManager.GetAccentCode(index).Should().NotBeNullOrEmpty();
+        Assert.False(string.IsNullOrEmpty(ThemeManager.GetAccentCode(index)));
     }
 
     [Theory]
@@ -41,7 +40,7 @@ public class ThemeCoverageTests
     [InlineData(9)]
     public void GetSecondaryAccent_IsNonEmpty_ForAllThemes(int index)
     {
-        ThemeManager.GetSecondaryAccent(index).Should().NotBeNullOrEmpty();
+        Assert.False(string.IsNullOrEmpty(ThemeManager.GetSecondaryAccent(index)));
     }
 
     [Theory]
@@ -57,7 +56,7 @@ public class ThemeCoverageTests
     [InlineData(9)]
     public void GetPanelHeaderBg_IsNonEmpty_ForAllThemes(int index)
     {
-        ThemeManager.GetPanelHeaderBg(index).Should().NotBeNullOrEmpty();
+        Assert.False(string.IsNullOrEmpty(ThemeManager.GetPanelHeaderBg(index)));
     }
 
     [Theory]
@@ -73,7 +72,7 @@ public class ThemeCoverageTests
     [InlineData(9)]
     public void GetPanelDetailBg_IsNonEmpty_ForAllThemes(int index)
     {
-        ThemeManager.GetPanelDetailBg(index).Should().NotBeNullOrEmpty();
+        Assert.False(string.IsNullOrEmpty(ThemeManager.GetPanelDetailBg(index)));
     }
 
     [Theory]
@@ -94,10 +93,10 @@ public class ThemeCoverageTests
         var headerBg = ThemeManager.GetPanelHeaderBg(index);
         var detailBg = ThemeManager.GetPanelDetailBg(index);
 
-        accent.Should().StartWith("\x1b[");
-        secondary.Should().StartWith("\x1b[");
-        headerBg.Should().StartWith("\x1b[");
-        detailBg.Should().StartWith("\x1b[");
+        Assert.StartsWith("\x1b[", accent);
+        Assert.StartsWith("\x1b[", secondary);
+        Assert.StartsWith("\x1b[", headerBg);
+        Assert.StartsWith("\x1b[", detailBg);
     }
 
     [Theory]
@@ -115,7 +114,7 @@ public class ThemeCoverageTests
     {
         var accent = ThemeManager.GetAccentCode(index);
         // All RGB foreground codes should be \x1b[38;2;RRR;GGG;BBBm — same format
-        accent.Should().Contain("38;2;", "all accents use RGB foreground codes");
+        Assert.Contains("38;2;", accent);
     }
 
     [Theory]
@@ -132,7 +131,7 @@ public class ThemeCoverageTests
     public void GetPanelBgColor_ReturnsNonNull_ForAllThemes(int index)
     {
         var color = ThemeManager.GetPanelBgColor(index);
-        color.Should().NotBeNull();
+        Assert.NotNull(color);
     }
 
     [Theory]
@@ -149,7 +148,7 @@ public class ThemeCoverageTests
     public void GetPanelDetailBgColor_ReturnsNonNull_ForAllThemes(int index)
     {
         var color = ThemeManager.GetPanelDetailBgColor(index);
-        color.Should().NotBeNull();
+        Assert.NotNull(color);
     }
 
     [Theory]
@@ -166,23 +165,23 @@ public class ThemeCoverageTests
     public void GetPanelAltBgColor_ReturnsNonNull_ForAllThemes(int index)
     {
         var color = ThemeManager.GetPanelAltBgColor(index);
-        color.Should().NotBeNull();
+        Assert.NotNull(color);
     }
 
     [Fact]
     public void ThemeCycling_WrapsAtIndex10()
     {
-        ThemeManager.GetAccentCode(10).Should().Be(ThemeManager.GetAccentCode(0));
-        ThemeManager.GetAccentCode(11).Should().Be(ThemeManager.GetAccentCode(1));
-        ThemeManager.GetAccentCode(19).Should().Be(ThemeManager.GetAccentCode(9));
-        ThemeManager.GetAccentCode(20).Should().Be(ThemeManager.GetAccentCode(0));
+        Assert.Equal(ThemeManager.GetAccentCode(0), ThemeManager.GetAccentCode(10));
+        Assert.Equal(ThemeManager.GetAccentCode(1), ThemeManager.GetAccentCode(11));
+        Assert.Equal(ThemeManager.GetAccentCode(9), ThemeManager.GetAccentCode(19));
+        Assert.Equal(ThemeManager.GetAccentCode(0), ThemeManager.GetAccentCode(20));
     }
 
     [Fact]
     public void ThemeCycling_SecondaryAccent_WrapsAtIndex10()
     {
-        ThemeManager.GetSecondaryAccent(10).Should().Be(ThemeManager.GetSecondaryAccent(0));
-        ThemeManager.GetSecondaryAccent(20).Should().Be(ThemeManager.GetSecondaryAccent(0));
+        Assert.Equal(ThemeManager.GetSecondaryAccent(0), ThemeManager.GetSecondaryAccent(10));
+        Assert.Equal(ThemeManager.GetSecondaryAccent(0), ThemeManager.GetSecondaryAccent(20));
     }
 
     [Fact]
@@ -191,9 +190,9 @@ public class ThemeCoverageTests
         for (int i = 0; i < 10; i++)
         {
             var rule = ThemeManager.GetDimRule(i, 20);
-            rule.Should().NotBeNullOrEmpty();
-            rule.Should().Contain("━", $"theme {i} dim rule should contain ━ chars");
-            rule.Should().Contain("\x1b[0m", $"theme {i} dim rule should end with reset");
+            Assert.False(string.IsNullOrEmpty(rule));
+            Assert.Contains("━", rule);
+            Assert.Contains("\x1b[0m", rule);
         }
     }
 
@@ -211,21 +210,21 @@ public class ThemeCoverageTests
     public void GetTheme_ReturnsThemeWithCorrectName(int index)
     {
         var theme = ThemeManager.GetTheme(index);
-        theme.Should().NotBeNull();
+        Assert.NotNull(theme);
     }
 
     [Fact]
     public void AllThemes_HaveDistinctAccentCodes()
     {
         var accents = Enumerable.Range(0, 10).Select(ThemeManager.GetAccentCode).ToList();
-        accents.Should().OnlyHaveUniqueItems("each theme should have a unique accent");
+        Assert.Equal(accents.Count, accents.Distinct().Count());
     }
 
     [Fact]
     public void AllThemes_HaveDistinctSecondaryAccents()
     {
         var secondaries = Enumerable.Range(0, 10).Select(ThemeManager.GetSecondaryAccent).ToList();
-        secondaries.Should().OnlyHaveUniqueItems("each theme should have a unique secondary accent");
+        Assert.Equal(secondaries.Count, secondaries.Distinct().Count());
     }
 
     [Fact]
@@ -236,7 +235,7 @@ public class ThemeCoverageTests
         {
             state.SelectedThemeIndex = i;
             var accent = ThemeManager.GetAccentCode(state.SelectedThemeIndex);
-            accent.Should().NotBeNullOrEmpty($"theme index {i} should produce valid accent");
+            Assert.False(string.IsNullOrEmpty(accent));
         }
     }
 }

--- a/tests/SquadTUI.Tests/Unit/MarkdownRendererTests.cs
+++ b/tests/SquadTUI.Tests/Unit/MarkdownRendererTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Rendering;
 
 namespace SquadTUI.Tests.Unit;
@@ -9,27 +8,27 @@ public class MarkdownRendererTests
     public void ExtractHeadings_FindsH1()
     {
         var headings = MarkdownRenderer.ExtractHeadings("# Title").ToList();
-        headings.Should().ContainSingle();
-        headings[0].Level.Should().Be(1);
-        headings[0].Text.Should().Be("Title");
+        Assert.Single(headings);
+        Assert.Equal(1, headings[0].Level);
+        Assert.Equal("Title", headings[0].Text);
     }
 
     [Fact]
     public void ExtractHeadings_FindsH2()
     {
         var headings = MarkdownRenderer.ExtractHeadings("## Section").ToList();
-        headings.Should().ContainSingle();
-        headings[0].Level.Should().Be(2);
-        headings[0].Text.Should().Be("Section");
+        Assert.Single(headings);
+        Assert.Equal(2, headings[0].Level);
+        Assert.Equal("Section", headings[0].Text);
     }
 
     [Fact]
     public void ExtractHeadings_FindsH3()
     {
         var headings = MarkdownRenderer.ExtractHeadings("### Subsection").ToList();
-        headings.Should().ContainSingle();
-        headings[0].Level.Should().Be(3);
-        headings[0].Text.Should().Be("Subsection");
+        Assert.Single(headings);
+        Assert.Equal(3, headings[0].Level);
+        Assert.Equal("Subsection", headings[0].Text);
     }
 
     [Fact]
@@ -37,21 +36,21 @@ public class MarkdownRendererTests
     {
         var md = "# Title\nSome text\n## Section A\nMore text\n## Section B\n### Sub";
         var headings = MarkdownRenderer.ExtractHeadings(md).ToList();
-        headings.Should().HaveCount(4);
+        Assert.Equal(4, headings.Count);
     }
 
     [Fact]
     public void ExtractHeadings_ReturnsEmpty_ForNoHeadings()
     {
         var headings = MarkdownRenderer.ExtractHeadings("Just plain text\nNo headings here").ToList();
-        headings.Should().BeEmpty();
+        Assert.Empty(headings);
     }
 
     [Fact]
     public void ExtractHeadings_HandlesEmptyString()
     {
         var headings = MarkdownRenderer.ExtractHeadings("").ToList();
-        headings.Should().BeEmpty();
+        Assert.Empty(headings);
     }
 
     [Theory]
@@ -61,7 +60,7 @@ public class MarkdownRendererTests
     public void ExtractHeadings_IgnoresHorizontalRules(string hr)
     {
         var headings = MarkdownRenderer.ExtractHeadings(hr).ToList();
-        headings.Should().BeEmpty();
+        Assert.Empty(headings);
     }
 
     [Fact]
@@ -81,10 +80,10 @@ Some paragraph text here.
 ## Another Section";
 
         var headings = MarkdownRenderer.ExtractHeadings(md).ToList();
-        headings.Should().HaveCount(4);
-        headings[0].Should().Be((1, "Main Title"));
-        headings[1].Should().Be((2, "Features"));
-        headings[2].Should().Be((3, "Details"));
-        headings[3].Should().Be((2, "Another Section"));
+        Assert.Equal(4, headings.Count);
+        Assert.Equal((1, "Main Title"), headings[0]);
+        Assert.Equal((2, "Features"), headings[1]);
+        Assert.Equal((3, "Details"), headings[2]);
+        Assert.Equal((2, "Another Section"), headings[3]);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Models/ModelTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Models/ModelTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Models;
 
 namespace SquadTUI.Tests.Unit.Models;
@@ -9,43 +8,43 @@ public class ModelTests
     public void SquadMember_DefaultsToActiveStatus()
     {
         var member = new SquadMember("Test", "Dev");
-        member.Status.Should().Be(MemberStatus.Active);
+        Assert.Equal(MemberStatus.Active, member.Status);
     }
 
     [Fact]
     public void SquadMember_DefaultsNullCurrentTask()
     {
         var member = new SquadMember("Test", "Dev");
-        member.CurrentTask.Should().BeNull();
+        Assert.Null(member.CurrentTask);
     }
 
     [Fact]
     public void SquadMember_DefaultsNullCharterPath()
     {
         var member = new SquadMember("Test", "Dev");
-        member.CharterPath.Should().BeNull();
+        Assert.Null(member.CharterPath);
     }
 
     [Fact]
     public void SquadTask_DefaultsToPendingStatus()
     {
         var task = new SquadTask("t1", "Test Task");
-        task.Status.Should().Be(SquadTaskStatus.Pending);
+        Assert.Equal(SquadTaskStatus.Pending, task.Status);
     }
 
     [Fact]
     public void SquadTask_DefaultsNullAssignee()
     {
         var task = new SquadTask("t1", "Test Task");
-        task.Assignee.Should().BeNull();
+        Assert.Null(task.Assignee);
     }
 
     [Fact]
     public void SquadTask_DefaultsNullTimestamps()
     {
         var task = new SquadTask("t1", "Test Task");
-        task.StartedAt.Should().BeNull();
-        task.CompletedAt.Should().BeNull();
+        Assert.Null(task.StartedAt);
+        Assert.Null(task.CompletedAt);
     }
 
     [Fact]
@@ -53,7 +52,7 @@ public class ModelTests
     {
         var a = new SquadMember("Danny", "Lead", MemberStatus.Active);
         var b = new SquadMember("Danny", "Lead", MemberStatus.Active);
-        a.Should().Be(b);
+        Assert.Equal(b, a);
     }
 
     [Fact]
@@ -61,7 +60,7 @@ public class ModelTests
     {
         var a = new SquadMember("Danny", "Lead", MemberStatus.Active);
         var b = new SquadMember("Danny", "Lead", MemberStatus.Idle);
-        a.Should().NotBe(b);
+        Assert.NotEqual(b, a);
     }
 
     [Fact]
@@ -69,7 +68,7 @@ public class ModelTests
     {
         var a = new SquadTask("t1", "Task", Status: SquadTaskStatus.Done);
         var b = new SquadTask("t1", "Task", Status: SquadTaskStatus.Done);
-        a.Should().Be(b);
+        Assert.Equal(b, a);
     }
 
     [Fact]
@@ -77,32 +76,32 @@ public class ModelTests
     {
         var original = new SquadMember("Danny", "Lead");
         var modified = original with { Status = MemberStatus.Working };
-        modified.Status.Should().Be(MemberStatus.Working);
-        original.Status.Should().Be(MemberStatus.Active);
+        Assert.Equal(MemberStatus.Working, modified.Status);
+        Assert.Equal(MemberStatus.Active, original.Status);
     }
 
     [Fact]
     public void DecisionEntry_StoresAllFields()
     {
         var entry = new DecisionEntry("Title", "2026-01-01", "Author", "Content", "/path", 5);
-        entry.Title.Should().Be("Title");
-        entry.Date.Should().Be("2026-01-01");
-        entry.Author.Should().Be("Author");
-        entry.Content.Should().Be("Content");
-        entry.FilePath.Should().Be("/path");
-        entry.LineNumber.Should().Be(5);
+        Assert.Equal("Title", entry.Title);
+        Assert.Equal("2026-01-01", entry.Date);
+        Assert.Equal("Author", entry.Author);
+        Assert.Equal("Content", entry.Content);
+        Assert.Equal("/path", entry.FilePath);
+        Assert.Equal(5, entry.LineNumber);
     }
 
     [Fact]
     public void Skill_StoresAllFields()
     {
         var skill = new Skill("test", "desc", "manual", "high", "body", "test-slug");
-        skill.Name.Should().Be("test");
-        skill.Description.Should().Be("desc");
-        skill.Source.Should().Be("manual");
-        skill.Confidence.Should().Be("high");
-        skill.Content.Should().Be("body");
-        skill.Slug.Should().Be("test-slug");
+        Assert.Equal("test", skill.Name);
+        Assert.Equal("desc", skill.Description);
+        Assert.Equal("manual", skill.Source);
+        Assert.Equal("high", skill.Confidence);
+        Assert.Equal("body", skill.Content);
+        Assert.Equal("test-slug", skill.Slug);
     }
 
     [Fact]
@@ -117,18 +116,18 @@ public class ModelTests
             ["Decision 1"],
             ["Outcome 1"],
             "Done stuff");
-        entry.Timestamp.Should().Be(DateTimeOffset.Parse("2026-02-16T00:00:00Z"));
-        entry.Participants.Should().HaveCount(2);
-        entry.Decisions.Should().ContainSingle();
-        entry.Outcomes.Should().ContainSingle();
-        entry.WhatWasDone.Should().Be("Done stuff");
+        Assert.Equal(DateTimeOffset.Parse("2026-02-16T00:00:00Z"), entry.Timestamp);
+        Assert.Equal(2, entry.Participants.Count);
+        Assert.Single(entry.Decisions);
+        Assert.Single(entry.Outcomes);
+        Assert.Equal("Done stuff", entry.WhatWasDone);
     }
 
     [Fact]
     public void TeamRoster_DefaultsNullMembers()
     {
         var roster = new TeamRoster("Test");
-        roster.Members.Should().BeNull();
-        roster.Description.Should().BeNull();
+        Assert.Null(roster.Members);
+        Assert.Null(roster.Description);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Rendering/PanelRendererTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Rendering/PanelRendererTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Rendering;
 using SquadTUI.Themes;
 
@@ -9,13 +8,13 @@ public class PanelRendererTests
     [Fact]
     public void Reset_ContainsAnsiResetCode()
     {
-        PanelRenderer.Reset.Should().Contain("\x1b[0m");
+        Assert.Contains("\x1b[0m", PanelRenderer.Reset);
     }
 
     [Fact]
     public void Bold_ContainsAnsiBoldCode()
     {
-        PanelRenderer.Bold.Should().Contain("\x1b[1m");
+        Assert.Contains("\x1b[1m", PanelRenderer.Bold);
     }
 
     [Theory]
@@ -26,6 +25,6 @@ public class PanelRendererTests
     public void GetPanelColors_ReturnsValidColorsForAllThemes(int themeIndex)
     {
         var colors = ThemeManager.GetPanelColors(themeIndex);
-        colors.Accent.Should().NotBeNullOrEmpty();
+        Assert.False(string.IsNullOrEmpty(colors.Accent));
     }
 }

--- a/tests/SquadTUI.Tests/Unit/SampleDataTests.cs
+++ b/tests/SquadTUI.Tests/Unit/SampleDataTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Tests.Fixtures;
 
 namespace SquadTUI.Tests.Unit;
@@ -12,8 +11,7 @@ public class SampleDataTests
         foreach (var task in SampleData.Tasks)
         {
             if (task.Assignee is not null)
-                memberNames.Should().Contain(task.Assignee,
-                    $"task '{task.Title}' assignee '{task.Assignee}' should exist in Members");
+                Assert.Contains(task.Assignee, memberNames);
         }
     }
 
@@ -25,8 +23,7 @@ public class SampleDataTests
         {
             foreach (var participant in log.Participants)
             {
-                memberNames.Should().Contain(participant,
-                    $"log '{log.Topic}' participant '{participant}' should exist in Members");
+                Assert.Contains(participant, memberNames);
             }
         }
     }
@@ -37,8 +34,7 @@ public class SampleDataTests
         foreach (var member in SampleData.Members)
         {
             var charter = SampleData.GetCharterFor(member.Name);
-            charter.Should().NotBeNullOrWhiteSpace(
-                $"charter for '{member.Name}' should be non-empty");
+            Assert.False(string.IsNullOrWhiteSpace(charter));
         }
     }
 
@@ -47,7 +43,7 @@ public class SampleDataTests
     {
         foreach (var member in SampleData.Members)
         {
-            member.Name.Should().NotBeNullOrWhiteSpace();
+            Assert.False(string.IsNullOrWhiteSpace(member.Name));
         }
     }
 
@@ -56,7 +52,7 @@ public class SampleDataTests
     {
         foreach (var member in SampleData.Members)
         {
-            member.Role.Should().NotBeNullOrWhiteSpace();
+            Assert.False(string.IsNullOrWhiteSpace(member.Role));
         }
     }
 
@@ -64,7 +60,7 @@ public class SampleDataTests
     public void Tasks_HaveUniqueIds()
     {
         var ids = SampleData.Tasks.Select(t => t.Id).ToList();
-        ids.Should().OnlyHaveUniqueItems();
+        Assert.Equal(ids.Distinct().Count(), ids.Count());
     }
 
     [Fact]
@@ -72,8 +68,7 @@ public class SampleDataTests
     {
         foreach (var decision in SampleData.Decisions)
         {
-            decision.Date.Should().NotBeNullOrWhiteSpace(
-                $"decision '{decision.Title}' should have a date");
+            Assert.False(string.IsNullOrWhiteSpace(decision.Date));
         }
     }
 
@@ -82,39 +77,38 @@ public class SampleDataTests
     {
         foreach (var decision in SampleData.Decisions)
         {
-            decision.Author.Should().NotBeNullOrWhiteSpace(
-                $"decision '{decision.Title}' should have an author");
+            Assert.False(string.IsNullOrWhiteSpace(decision.Author));
         }
     }
 
     [Fact]
     public void Members_HasAtLeastOneEntry()
     {
-        SampleData.Members.Should().NotBeEmpty();
+        Assert.NotEmpty(SampleData.Members);
     }
 
     [Fact]
     public void Tasks_HasAtLeastOneEntry()
     {
-        SampleData.Tasks.Should().NotBeEmpty();
+        Assert.NotEmpty(SampleData.Tasks);
     }
 
     [Fact]
     public void Decisions_HasAtLeastOneEntry()
     {
-        SampleData.Decisions.Should().NotBeEmpty();
+        Assert.NotEmpty(SampleData.Decisions);
     }
 
     [Fact]
     public void Skills_HasAtLeastOneEntry()
     {
-        SampleData.Skills.Should().NotBeEmpty();
+        Assert.NotEmpty(SampleData.Skills);
     }
 
     [Fact]
     public void LogEntries_HasAtLeastOneEntry()
     {
-        SampleData.LogEntries.Should().NotBeEmpty();
+        Assert.NotEmpty(SampleData.LogEntries);
     }
 
     [Fact]
@@ -122,7 +116,7 @@ public class SampleDataTests
     {
         foreach (var skill in SampleData.Skills)
         {
-            skill.Name.Should().NotBeNullOrWhiteSpace();
+            Assert.False(string.IsNullOrWhiteSpace(skill.Name));
         }
     }
 
@@ -131,7 +125,7 @@ public class SampleDataTests
     {
         foreach (var skill in SampleData.Skills)
         {
-            skill.Description.Should().NotBeNullOrWhiteSpace();
+            Assert.False(string.IsNullOrWhiteSpace(skill.Description));
         }
     }
 
@@ -139,33 +133,33 @@ public class SampleDataTests
     public void GetCharterFor_UnknownMember_ReturnsFallback()
     {
         var charter = SampleData.GetCharterFor("UnknownPerson");
-        charter.Should().Contain("No charter available yet.");
+        Assert.Contains("No charter available yet.", charter);
     }
 
     [Fact]
     public void SprintHistory_Has3Entries()
     {
-        SampleData.SprintHistory.Should().HaveCount(3);
+        Assert.Equal(3, SampleData.SprintHistory.Count);
     }
 
     [Fact]
     public void OverallCompletionRate_IsBetween0And100()
     {
-        SampleData.OverallCompletionRate.Should().BeInRange(0, 100);
+        Assert.InRange(SampleData.OverallCompletionRate, 0, 100);
     }
 
     [Fact]
     public void AverageVelocity_IsPositive()
     {
-        SampleData.AverageVelocity.Should().BeGreaterThan(0);
+        Assert.True(SampleData.AverageVelocity > 0);
     }
 
     [Fact]
     public void VelocityTrend_ReturnsValidNumber()
     {
         var trend = SampleData.VelocityTrend;
-        double.IsNaN(trend).Should().BeFalse();
-        double.IsInfinity(trend).Should().BeFalse();
+        Assert.False(double.IsNaN(trend));
+        Assert.False(double.IsInfinity(trend));
     }
 
     [Fact]
@@ -175,9 +169,8 @@ public class SampleDataTests
         var utilization = SampleData.TeamUtilization;
         foreach (var entry in utilization)
         {
-            memberNames.Should().Contain(entry.Name,
-                $"utilization entry '{entry.Name}' should match a member");
-            entry.Utilization.Should().BeInRange(0, 100);
+            Assert.Contains(entry.Name, memberNames);
+            Assert.InRange(entry.Utilization, 0, 100);
         }
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Screens/AppStateTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Screens/AppStateTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using LanguageExt;
 using static LanguageExt.Prelude;
 using SquadTUI.Screens;
@@ -13,34 +12,34 @@ public class AppStateTests
     public void AppState_DefaultsToSquadDetected()
     {
         var state = new AppState();
-        state.SquadDetected.Should().BeTrue();
+        Assert.True(state.SquadDetected);
     }
 
     [Fact]
     public void AppState_DefaultsToDashboard()
     {
         var state = new AppState();
-        state.CurrentScreen.Should().Be(Screen.Dashboard);
+        Assert.Equal(Screen.Dashboard, state.CurrentScreen);
     }
 
     [Fact]
     public void AppState_HasSettingsProperty()
     {
         var state = new AppState();
-        state.Settings.Should().NotBeNull();
+        Assert.NotNull(state.Settings);
     }
 
     [Fact]
     public void Screen_Enum_IncludesNoSquad()
     {
-        Enum.IsDefined(typeof(Screen), Screen.NoSquad).Should().BeTrue();
+        Assert.True(Enum.IsDefined(typeof(Screen), Screen.NoSquad));
     }
 
     [Fact]
     public void RosterSelectedIndex_DefaultsToZero()
     {
         var state = new AppState();
-        state.RosterSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.RosterSelectedIndex);
     }
 
     [Fact]
@@ -50,7 +49,7 @@ public class AppStateTests
         state.Members = Right<AppError, IReadOnlyList<SquadMember>>(new List<SquadMember>());
         // Simulate K press logic: Math.Max(index - 1, 0)
         state.RosterSelectedIndex = Math.Max(state.RosterSelectedIndex - 1, 0);
-        state.RosterSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.RosterSelectedIndex);
     }
 
     [Fact]
@@ -60,7 +59,7 @@ public class AppStateTests
         state.DecisionSelectedIndex = 0;
         // Simulate K press: Math.Max(index - 1, 0)
         state.DecisionSelectedIndex = Math.Max(state.DecisionSelectedIndex - 1, 0);
-        state.DecisionSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.DecisionSelectedIndex);
     }
 
     [Fact]
@@ -72,7 +71,7 @@ public class AppStateTests
         // Simulate J press: Math.Min(index + 1, count - 1)
         state.SkillSelectedIndex = maxIndex;
         state.SkillSelectedIndex = Math.Min(state.SkillSelectedIndex + 1, maxIndex);
-        state.SkillSelectedIndex.Should().Be(maxIndex);
+        Assert.Equal(maxIndex, state.SkillSelectedIndex);
     }
 
     [Fact]
@@ -82,12 +81,12 @@ public class AppStateTests
         // Simulate J press at max: Math.Min(index + 1, 4)
         state.SettingsSelectedIndex = 4;
         state.SettingsSelectedIndex = Math.Min(state.SettingsSelectedIndex + 1, 4);
-        state.SettingsSelectedIndex.Should().Be(4);
+        Assert.Equal(4, state.SettingsSelectedIndex);
 
         // Simulate K press at min: Math.Max(index - 1, 0)
         state.SettingsSelectedIndex = 0;
         state.SettingsSelectedIndex = Math.Max(state.SettingsSelectedIndex - 1, 0);
-        state.SettingsSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.SettingsSelectedIndex);
     }
 
     [Fact]
@@ -100,26 +99,26 @@ public class AppStateTests
         // Try to go past the end
         state.LogSelectedIndex = maxIndex;
         state.LogSelectedIndex = Math.Min(state.LogSelectedIndex + 1, maxIndex);
-        state.LogSelectedIndex.Should().Be(maxIndex);
+        Assert.Equal(maxIndex, state.LogSelectedIndex);
 
         // Try to go before the beginning
         state.LogSelectedIndex = 0;
         state.LogSelectedIndex = Math.Max(state.LogSelectedIndex - 1, 0);
-        state.LogSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.LogSelectedIndex);
     }
 
     [Fact]
     public void IsLiveEnabled_DefaultsToTrue()
     {
         var state = new AppState();
-        state.IsLiveEnabled.Should().BeTrue();
+        Assert.True(state.IsLiveEnabled);
     }
 
     [Fact]
     public void HasPendingRefresh_DefaultsToFalse()
     {
         var state = new AppState();
-        state.HasPendingRefresh.Should().BeFalse();
+        Assert.False(state.HasPendingRefresh);
     }
 
     [Fact]
@@ -127,39 +126,39 @@ public class AppStateTests
     {
         var before = DateTime.Now;
         var state = new AppState();
-        state.LastRefreshTime.Should().BeOnOrAfter(before);
+        Assert.True(state.LastRefreshTime >= before);
     }
 
     [Fact]
     public void ShowSettingsOverlay_DefaultsToFalse()
     {
         var state = new AppState();
-        state.ShowSettingsOverlay.Should().BeFalse();
+        Assert.False(state.ShowSettingsOverlay);
     }
 
     [Fact]
     public void PreviewThemeIndex_DefaultsToNegativeOne()
     {
         var state = new AppState();
-        state.PreviewThemeIndex.Should().Be(-1);
+        Assert.Equal(-1, state.PreviewThemeIndex);
     }
 
     [Fact]
     public void OriginalThemeIndex_DefaultsToZero()
     {
         var state = new AppState();
-        state.OriginalThemeIndex.Should().Be(0);
+        Assert.Equal(0, state.OriginalThemeIndex);
     }
 
     [Fact]
     public void AllSelectedIndices_DefaultToZero()
     {
         var state = new AppState();
-        state.RosterSelectedIndex.Should().Be(0);
-        state.DecisionSelectedIndex.Should().Be(0);
-        state.LogSelectedIndex.Should().Be(0);
-        state.SkillSelectedIndex.Should().Be(0);
-        state.SettingsSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.RosterSelectedIndex);
+        Assert.Equal(0, state.DecisionSelectedIndex);
+        Assert.Equal(0, state.LogSelectedIndex);
+        Assert.Equal(0, state.SkillSelectedIndex);
+        Assert.Equal(0, state.SettingsSelectedIndex);
     }
 
     [Fact]
@@ -174,13 +173,13 @@ public class AppStateTests
         {
             state.RosterSelectedIndex = Math.Min(state.RosterSelectedIndex + 1, count - 1);
         }
-        state.RosterSelectedIndex.Should().Be(count - 1);
+        Assert.Equal(count - 1, state.RosterSelectedIndex);
 
         // Navigate all the way back up
         for (int i = 0; i < count + 5; i++)
         {
             state.RosterSelectedIndex = Math.Max(state.RosterSelectedIndex - 1, 0);
         }
-        state.RosterSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.RosterSelectedIndex);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Screens/HelpScreenTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Screens/HelpScreenTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Screens;
 
 namespace SquadTUI.Tests.Unit.Screens;
@@ -8,14 +7,14 @@ public class HelpScreenTests
     [Fact]
     public void Screen_Enum_IncludesHelp()
     {
-        Enum.IsDefined(typeof(Screen), Screen.Help).Should().BeTrue();
+        Assert.True(Enum.IsDefined(typeof(Screen), Screen.Help));
     }
 
     [Fact]
     public void AppState_PreviousScreen_DefaultsToNull()
     {
         var state = new AppState();
-        state.PreviousScreen.Should().BeNull();
+        Assert.Null(state.PreviousScreen);
     }
 
     [Fact]
@@ -23,13 +22,13 @@ public class HelpScreenTests
     {
         var state = new AppState();
         state.PreviousScreen = Screen.Roster;
-        state.PreviousScreen.Should().Be(Screen.Roster);
+        Assert.Equal(Screen.Roster, state.PreviousScreen);
     }
 
     [Fact]
     public void AppState_ShowHelp_DefaultsFalse()
     {
         var state = new AppState();
-        state.ShowHelp.Should().BeFalse();
+        Assert.False(state.ShowHelp);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Screens/MetricsChartDataTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Screens/MetricsChartDataTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Screens;
 using SquadTUI.Tests.Fixtures;
 
@@ -10,7 +9,7 @@ public class MetricsChartDataTests
     public void ShowBurndown_DefaultsToFalse()
     {
         var state = new AppState();
-        state.ShowBurndown.Should().BeFalse();
+        Assert.False(state.ShowBurndown);
     }
 
     [Fact]
@@ -18,15 +17,15 @@ public class MetricsChartDataTests
     {
         var state = new AppState();
         state.ShowBurndown = true;
-        state.ShowBurndown.Should().BeTrue();
+        Assert.True(state.ShowBurndown);
         state.ShowBurndown = false;
-        state.ShowBurndown.Should().BeFalse();
+        Assert.False(state.ShowBurndown);
     }
 
     [Fact]
     public void SprintHistory_HasData()
     {
-        SampleData.SprintHistory.Should().HaveCountGreaterThanOrEqualTo(1);
+        Assert.True(SampleData.SprintHistory.Count() >= 1);
     }
 
     [Fact]
@@ -34,8 +33,8 @@ public class MetricsChartDataTests
     {
         foreach (var sprint in SampleData.SprintHistory)
         {
-            sprint.PlannedTasks.Should().BeGreaterThanOrEqualTo(0);
-            sprint.CompletedTasks.Should().BeGreaterThanOrEqualTo(0);
+            Assert.True(sprint.PlannedTasks >= 0);
+            Assert.True(sprint.CompletedTasks >= 0);
         }
     }
 
@@ -44,21 +43,21 @@ public class MetricsChartDataTests
     {
         foreach (var sprint in SampleData.SprintHistory)
         {
-            sprint.Contributions.Should().HaveCountGreaterThanOrEqualTo(1);
+            Assert.True(sprint.Contributions.Count() >= 1);
         }
     }
 
     [Fact]
     public void OverallCompletionRate_InValidRange()
     {
-        SampleData.OverallCompletionRate.Should().BeGreaterThanOrEqualTo(0);
-        SampleData.OverallCompletionRate.Should().BeLessThanOrEqualTo(100);
+        Assert.True(SampleData.OverallCompletionRate >= 0);
+        Assert.True(SampleData.OverallCompletionRate <= 100);
     }
 
     [Fact]
     public void AverageVelocity_IsPositive()
     {
-        SampleData.AverageVelocity.Should().BeGreaterThanOrEqualTo(0);
+        Assert.True(SampleData.AverageVelocity >= 0);
     }
 
     [Fact]
@@ -66,8 +65,8 @@ public class MetricsChartDataTests
     {
         foreach (var sprint in SampleData.SprintHistory)
         {
-            sprint.CompletionRate.Should().BeGreaterThanOrEqualTo(0);
-            sprint.CompletionRate.Should().BeLessThanOrEqualTo(100);
+            Assert.True(sprint.CompletionRate >= 0);
+            Assert.True(sprint.CompletionRate <= 100);
         }
     }
 
@@ -76,7 +75,7 @@ public class MetricsChartDataTests
     {
         foreach (var sprint in SampleData.SprintHistory)
         {
-            sprint.CarriedOver.Should().BeGreaterThanOrEqualTo(0);
+            Assert.True(sprint.CarriedOver >= 0);
         }
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Screens/SettingsScreenTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Screens/SettingsScreenTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Screens;
 
 namespace SquadTUI.Tests.Unit.Screens;
@@ -8,48 +7,48 @@ public class SettingsScreenTests
     [Fact]
     public void Screen_Enum_IncludesSettings()
     {
-        Enum.IsDefined(typeof(Screen), Screen.Settings).Should().BeTrue();
+        Assert.True(Enum.IsDefined(typeof(Screen), Screen.Settings));
     }
 
     [Fact]
     public void AppState_SettingsSelectedIndex_DefaultsToZero()
     {
         var state = new AppState();
-        state.SettingsSelectedIndex.Should().Be(0);
+        Assert.Equal(0, state.SettingsSelectedIndex);
     }
 
     [Fact]
     public void AppState_Settings_HasDefaultThemeName()
     {
         var state = new AppState();
-        state.Settings.ThemeName.Should().Be("Ocean");
+        Assert.Equal("Ocean", state.Settings.ThemeName);
     }
 
     [Fact]
     public void AppState_Settings_VimBindings_DefaultsTrue()
     {
         var state = new AppState();
-        state.Settings.VimBindings.Should().BeTrue();
+        Assert.True(state.Settings.VimBindings);
     }
 
     [Fact]
     public void AppState_Settings_MouseEnabled_DefaultsTrue()
     {
         var state = new AppState();
-        state.Settings.MouseEnabled.Should().BeTrue();
+        Assert.True(state.Settings.MouseEnabled);
     }
 
     [Fact]
     public void AppState_Settings_ShowEmoji_DefaultsTrue()
     {
         var state = new AppState();
-        state.Settings.ShowEmoji.Should().BeTrue();
+        Assert.True(state.Settings.ShowEmoji);
     }
 
     [Fact]
     public void AppState_Settings_MarkdownRendering_DefaultsTrue()
     {
         var state = new AppState();
-        state.Settings.MarkdownRendering.Should().BeTrue();
+        Assert.True(state.Settings.MarkdownRendering);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Services/DecisionServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/DecisionServiceTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Unit.Services;
@@ -64,7 +63,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.Should().HaveCount(3);
+        Assert.Equal(3, decisions.Count);
     }
 
     [Fact]
@@ -85,9 +84,9 @@ public class DecisionServiceTests : IDisposable
         var decisions = await svc.GetDecisionsAsync();
 
         var d = decisions.First();
-        d.Title.Should().Be("Architecture Decision");
-        d.Date.Should().Be("2026-02-16");
-        d.Author.Should().Be("Danny");
+        Assert.Equal("Architecture Decision", d.Title);
+        Assert.Equal("2026-02-16", d.Date);
+        Assert.Equal("Danny", d.Author);
     }
 
     [Fact]
@@ -105,9 +104,9 @@ public class DecisionServiceTests : IDisposable
         var decisions = await svc.GetDecisionsAsync();
 
         var d = decisions.First();
-        d.Title.Should().Be("Simple Decision");
-        d.Date.Should().BeEmpty();
-        d.Author.Should().BeEmpty();
+        Assert.Equal("Simple Decision", d.Title);
+        Assert.Empty(d.Date);
+        Assert.Empty(d.Author);
     }
 
     [Fact]
@@ -127,7 +126,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.First().Content.Should().Contain("This is the content of the decision.");
+        Assert.Contains("This is the content of the decision.", decisions.First().Content);
     }
 
     [Fact]
@@ -152,7 +151,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.Should().HaveCount(2);
+        Assert.Equal(2, decisions.Count);
     }
 
     [Fact]
@@ -167,7 +166,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.Should().BeEmpty();
+        Assert.Empty(decisions);
     }
 
     [Fact]
@@ -176,7 +175,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.Should().BeEmpty();
+        Assert.Empty(decisions);
     }
 
     [Fact]
@@ -185,7 +184,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.Should().BeEmpty();
+        Assert.Empty(decisions);
     }
 
     [Fact]
@@ -202,7 +201,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.First().Date.Should().Be("2026-02-16");
+        Assert.Equal("2026-02-16", decisions.First().Date);
     }
 
     [Fact]
@@ -223,8 +222,8 @@ public class DecisionServiceTests : IDisposable
         var decisions = await svc.GetDecisionsAsync();
 
         var d = decisions.First();
-        d.Date.Should().Be("2026-02-17");
-        d.Author.Should().Be("Saul");
+        Assert.Equal("2026-02-17", d.Date);
+        Assert.Equal("Saul", d.Author);
     }
 
     [Fact]
@@ -241,7 +240,7 @@ public class DecisionServiceTests : IDisposable
         var svc = new DecisionService(SquadDir);
         var decisions = await svc.GetDecisionsAsync();
 
-        decisions.First().FilePath.Should().NotBeNull();
-        decisions.First().LineNumber.Should().BeGreaterThan(0);
+        Assert.NotNull(decisions.First().FilePath);
+        Assert.True(decisions.First().LineNumber > 0);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Services/FileWatcherServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/FileWatcherServiceTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Unit.Services;
@@ -25,7 +24,7 @@ public class FileWatcherServiceTests : IDisposable
     public void IsWatching_IsFalse_ByDefault()
     {
         using var svc = new FileWatcherService();
-        svc.IsWatching.Should().BeFalse();
+        Assert.False(svc.IsWatching);
     }
 
     [Fact]
@@ -33,7 +32,7 @@ public class FileWatcherServiceTests : IDisposable
     {
         using var svc = new FileWatcherService();
         svc.Start(_tempDir);
-        svc.IsWatching.Should().BeTrue();
+        Assert.True(svc.IsWatching);
     }
 
     [Fact]
@@ -42,7 +41,7 @@ public class FileWatcherServiceTests : IDisposable
         using var svc = new FileWatcherService();
         svc.Start(_tempDir);
         svc.Stop();
-        svc.IsWatching.Should().BeFalse();
+        Assert.False(svc.IsWatching);
     }
 
     [Fact]
@@ -51,7 +50,7 @@ public class FileWatcherServiceTests : IDisposable
         using var svc = new FileWatcherService();
         var nonExistent = Path.Combine(Path.GetTempPath(), "SquadTUI_NoExist_" + Guid.NewGuid().ToString("N"));
         svc.Start(nonExistent);
-        svc.IsWatching.Should().BeFalse();
+        Assert.False(svc.IsWatching);
     }
 
     [Fact]
@@ -60,7 +59,7 @@ public class FileWatcherServiceTests : IDisposable
         using var svc = new FileWatcherService();
         svc.Start(_tempDir);
         svc.Start(_tempDir); // idempotent
-        svc.IsWatching.Should().BeTrue();
+        Assert.True(svc.IsWatching);
     }
 
     [Fact]
@@ -69,7 +68,7 @@ public class FileWatcherServiceTests : IDisposable
         var svc = new FileWatcherService();
         svc.Start(_tempDir);
         svc.Dispose();
-        svc.IsWatching.Should().BeFalse();
+        Assert.False(svc.IsWatching);
     }
 
     [Fact]
@@ -84,7 +83,7 @@ public class FileWatcherServiceTests : IDisposable
 
         // Wait for the event to propagate (FileSystemWatcher is async)
         await Task.Delay(500);
-        fired.Should().BeTrue();
+        Assert.True(fired);
     }
 
     [Fact]
@@ -104,6 +103,6 @@ public class FileWatcherServiceTests : IDisposable
 
         await Task.Delay(500);
         // Debounce (2s window) means only 1 event should fire for rapid writes
-        fireCount.Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(2);
+        Assert.True(fireCount > 0 && fireCount <= 2);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Services/OrchestrationLogServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/OrchestrationLogServiceTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Unit.Services;
@@ -41,8 +40,8 @@ public class OrchestrationLogServiceTests : IDisposable
         var entries = await svc.GetEntriesAsync();
 
         var entry = entries.First();
-        entry.Date.Should().Be("2026-02-16");
-        entry.Topic.Should().Be("kickoff");
+        Assert.Equal("2026-02-16", entry.Date);
+        Assert.Equal("kickoff", entry.Topic);
     }
 
     [Fact]
@@ -61,8 +60,10 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesAsync();
 
-        entries.First().Participants.Should().HaveCount(3);
-        entries.First().Participants.Should().Contain(["Danny", "Linus", "Rusty"]);
+        Assert.Equal(3, entries.First().Participants.Count);
+        Assert.Contains("Danny", entries.First().Participants);
+        Assert.Contains("Linus", entries.First().Participants);
+        Assert.Contains("Rusty", entries.First().Participants);
     }
 
     [Fact]
@@ -80,8 +81,8 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesAsync();
 
-        entries.First().Decisions.Should().HaveCount(2);
-        entries.First().Decisions.Should().Contain("Use Hex1b framework");
+        Assert.Equal(2, entries.First().Decisions.Count);
+        Assert.Contains("Use Hex1b framework", entries.First().Decisions);
     }
 
     [Fact]
@@ -99,8 +100,8 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesAsync();
 
-        entries.First().Outcomes.Should().HaveCount(2);
-        entries.First().Outcomes.Should().Contain("Repository initialized");
+        Assert.Equal(2, entries.First().Outcomes.Count);
+        Assert.Contains("Repository initialized", entries.First().Outcomes);
     }
 
     [Fact]
@@ -109,7 +110,7 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesAsync();
 
-        entries.Should().BeEmpty();
+        Assert.Empty(entries);
     }
 
     [Fact]
@@ -121,7 +122,7 @@ public class OrchestrationLogServiceTests : IDisposable
         {
             var svc = new OrchestrationLogService(emptyDir);
             var entries = await svc.GetEntriesAsync();
-            entries.Should().BeEmpty();
+            Assert.Empty(entries);
         }
         finally
         {
@@ -145,10 +146,10 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesAsync();
 
-        entries.Should().HaveCount(3);
-        entries[0].Date.Should().Be("2026-02-17");
-        entries[1].Date.Should().Be("2026-02-16");
-        entries[2].Date.Should().Be("2026-02-15");
+        Assert.Equal(3, entries.Count);
+        Assert.Equal("2026-02-17", entries[0].Date);
+        Assert.Equal("2026-02-16", entries[1].Date);
+        Assert.Equal("2026-02-15", entries[2].Date);
     }
 
     [Fact]
@@ -164,8 +165,8 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesByDateAsync("2026-02-16");
 
-        entries.Should().ContainSingle();
-        entries.First().Date.Should().Be("2026-02-16");
+        Assert.Single(entries);
+        Assert.Equal("2026-02-16", entries.First().Date);
     }
 
     [Fact]
@@ -182,7 +183,7 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesAsync();
 
-        entries.First().Summary.Should().Be("Project Kickoff Session");
+        Assert.Equal("Project Kickoff Session", entries.First().Summary);
     }
 
     [Fact]
@@ -197,6 +198,6 @@ public class OrchestrationLogServiceTests : IDisposable
         var svc = new OrchestrationLogService(SquadDir);
         var entries = await svc.GetEntriesAsync();
 
-        entries.First().Topic.Should().Be("sprint planning session");
+        Assert.Equal("sprint planning session", entries.First().Topic);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Services/SettingsServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/SettingsServiceTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Models;
 using SquadTUI.Services;
 
@@ -10,11 +9,11 @@ public class SettingsServiceTests
     public void DefaultSettings_HaveExpectedValues()
     {
         var settings = new AppSettings();
-        settings.ThemeName.Should().Be("Ocean");
-        settings.VimBindings.Should().BeTrue();
-        settings.MouseEnabled.Should().BeTrue();
-        settings.ShowEmoji.Should().BeTrue();
-        settings.MarkdownRendering.Should().BeTrue();
-        settings.DefaultScreen.Should().Be("Dashboard");
+        Assert.Equal("Ocean", settings.ThemeName);
+        Assert.True(settings.VimBindings);
+        Assert.True(settings.MouseEnabled);
+        Assert.True(settings.ShowEmoji);
+        Assert.True(settings.MarkdownRendering);
+        Assert.Equal("Dashboard", settings.DefaultScreen);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Services/SkillServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/SkillServiceTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Unit.Services;
@@ -48,11 +47,11 @@ public class SkillServiceTests : IDisposable
         var skills = await svc.GetSkillsAsync();
 
         var skill = skills.First();
-        skill.Name.Should().Be("Test Skill");
-        skill.Description.Should().Be("A test skill");
-        skill.Source.Should().Be("manual");
-        skill.Confidence.Should().Be("high");
-        skill.Slug.Should().Be("test-skill");
+        Assert.Equal("Test Skill", skill.Name);
+        Assert.Equal("A test skill", skill.Description);
+        Assert.Equal("manual", skill.Source);
+        Assert.Equal("high", skill.Confidence);
+        Assert.Equal("test-skill", skill.Slug);
     }
 
     [Fact]
@@ -68,8 +67,8 @@ public class SkillServiceTests : IDisposable
         var skills = await svc.GetSkillsAsync();
 
         var skill = skills.First();
-        skill.Name.Should().Be("My Custom Skill");
-        skill.Description.Should().BeEmpty();
+        Assert.Equal("My Custom Skill", skill.Name);
+        Assert.Empty(skill.Description);
     }
 
     [Fact]
@@ -81,7 +80,7 @@ public class SkillServiceTests : IDisposable
         {
             var svc = new SkillService(emptyDir);
             var skills = await svc.GetSkillsAsync();
-            skills.Should().BeEmpty();
+            Assert.Empty(skills);
         }
         finally
         {
@@ -99,7 +98,7 @@ public class SkillServiceTests : IDisposable
         var svc = new SkillService(SquadDir);
         var skills = await svc.GetSkillsAsync();
 
-        skills.Should().BeEmpty();
+        Assert.Empty(skills);
     }
 
     [Fact]
@@ -108,7 +107,7 @@ public class SkillServiceTests : IDisposable
         var svc = new SkillService(SquadDir);
         var skill = await svc.GetSkillAsync("nonexistent");
 
-        skill.Should().BeNull();
+        Assert.Null(skill);
     }
 
     [Fact]
@@ -126,9 +125,9 @@ public class SkillServiceTests : IDisposable
         var svc = new SkillService(SquadDir);
         var skill = await svc.GetSkillAsync("code-review");
 
-        skill.Should().NotBeNull();
-        skill!.Name.Should().Be("Code Review");
-        skill.Slug.Should().Be("code-review");
+        Assert.NotNull(skill);
+        Assert.Equal("Code Review", skill!.Name);
+        Assert.Equal("code-review", skill.Slug);
     }
 
     [Fact]
@@ -149,8 +148,8 @@ public class SkillServiceTests : IDisposable
         var svc = new SkillService(SquadDir);
         var skills = await svc.GetSkillsAsync();
 
-        skills.First().Content.Should().Contain("Body content line 1.");
-        skills.First().Content.Should().Contain("Body content line 2.");
+        Assert.Contains("Body content line 1.", skills.First().Content);
+        Assert.Contains("Body content line 2.", skills.First().Content);
     }
 
     [Fact]
@@ -163,7 +162,7 @@ public class SkillServiceTests : IDisposable
         var svc = new SkillService(SquadDir);
         var skills = await svc.GetSkillsAsync();
 
-        skills.First().Name.Should().Be("fallback-name");
+        Assert.Equal("fallback-name", skills.First().Name);
     }
 
     [Fact]
@@ -186,6 +185,6 @@ public class SkillServiceTests : IDisposable
         var svc = new SkillService(SquadDir);
         var skills = await svc.GetSkillsAsync();
 
-        skills.Should().HaveCount(2);
+        Assert.Equal(2, skills.Count);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Services/SquadDataProviderTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/SquadDataProviderTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using NSubstitute;
 using SquadTUI.Models;
 using SquadTUI.Services;
@@ -39,9 +38,9 @@ public class SquadDataProviderTests
 
         var dashboard = await _provider.GetDashboardAsync();
 
-        dashboard.Team.Should().NotBeNull();
-        dashboard.Decisions.Should().NotBeEmpty();
-        dashboard.Activity.Should().NotBeEmpty();
+        Assert.NotNull(dashboard.Team);
+        Assert.NotEmpty(dashboard.Decisions);
+        Assert.NotEmpty(dashboard.Activity);
     }
 
     [Fact]
@@ -61,8 +60,8 @@ public class SquadDataProviderTests
 
         var dashboard = await _provider.GetDashboardAsync();
 
-        dashboard.Team.TotalMembers.Should().Be(3);
-        dashboard.Team.ActiveMembers.Should().Be(2); // Active + Working
+        Assert.Equal(3, dashboard.Team.TotalMembers);
+        Assert.Equal(2, dashboard.Team.ActiveMembers); // Active + Working
     }
 
     [Fact]
@@ -84,9 +83,9 @@ public class SquadDataProviderTests
 
         var dashboard = await _provider.GetDashboardAsync();
 
-        dashboard.Activity.Should().ContainSingle();
-        dashboard.Activity[0].MemberName.Should().Be("Danny");
-        dashboard.Activity[0].LogEntries.Should().ContainSingle();
+        Assert.Single(dashboard.Activity);
+        Assert.Equal("Danny", dashboard.Activity[0].MemberName);
+        Assert.Single(dashboard.Activity[0].LogEntries);
     }
 
     [Fact]
@@ -97,7 +96,7 @@ public class SquadDataProviderTests
 
         var result = await _provider.GetRosterAsync();
 
-        result.Should().Be(roster);
+        Assert.Equal(roster, result);
     }
 
     [Fact]
@@ -108,7 +107,7 @@ public class SquadDataProviderTests
 
         var result = await _provider.GetDecisionsAsync();
 
-        result.Should().BeEquivalentTo(decisions);
+        Assert.Equal(decisions, result);
     }
 
     [Fact]
@@ -122,7 +121,7 @@ public class SquadDataProviderTests
 
         var result = await _provider.GetLogEntriesAsync();
 
-        result.Should().BeEquivalentTo(logs);
+        Assert.Equal(logs, result);
     }
 
     [Fact]
@@ -133,6 +132,6 @@ public class SquadDataProviderTests
 
         var result = await _provider.GetSkillsAsync();
 
-        result.Should().BeEquivalentTo(skills);
+        Assert.Equal(skills, result);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/Services/SquadDetectorTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/SquadDetectorTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Unit.Services;
@@ -15,7 +14,7 @@ public class SquadDetectorTests
             Directory.CreateDirectory(aiTeamDir);
             File.WriteAllText(Path.Combine(aiTeamDir, "team.md"), "# Team");
 
-            SquadDetector.HasValidSquad(tempDir).Should().BeTrue();
+            Assert.True(SquadDetector.HasValidSquad(tempDir));
         }
         finally
         {
@@ -32,7 +31,7 @@ public class SquadDetectorTests
             var agentsDir = Path.Combine(tempDir, ".ai-team", "agents");
             Directory.CreateDirectory(agentsDir);
 
-            SquadDetector.HasValidSquad(tempDir).Should().BeTrue();
+            Assert.True(SquadDetector.HasValidSquad(tempDir));
         }
         finally
         {
@@ -47,7 +46,7 @@ public class SquadDetectorTests
         try
         {
             Directory.CreateDirectory(tempDir);
-            SquadDetector.HasValidSquad(tempDir).Should().BeFalse();
+            Assert.False(SquadDetector.HasValidSquad(tempDir));
         }
         finally
         {
@@ -63,7 +62,7 @@ public class SquadDetectorTests
         {
             Directory.CreateDirectory(Path.Combine(tempDir, ".ai-team"));
             // No team.md and no agents dir
-            SquadDetector.HasValidSquad(tempDir).Should().BeFalse();
+            Assert.False(SquadDetector.HasValidSquad(tempDir));
         }
         finally
         {

--- a/tests/SquadTUI.Tests/Unit/Services/TeamServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/TeamServiceTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Models;
 using SquadTUI.Services;
 
@@ -52,7 +51,7 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Members.Should().HaveCount(3);
+        Assert.Equal(3, roster.Members.Count);
     }
 
     [Fact]
@@ -72,7 +71,8 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Members!.Select(m => m.Name).Should().Contain(["Danny", "Linus"]);
+        Assert.Contains("Danny", roster.Members!.Select(m => m.Name));
+        Assert.Contains("Linus", roster.Members!.Select(m => m.Name));
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Members!.First().Role.Should().Be("Lead");
+        Assert.Equal("Lead", roster.Members!.First().Role);
     }
 
     [Fact]
@@ -113,9 +113,9 @@ public class TeamServiceTests : IDisposable
         var roster = await svc.GetRosterAsync();
 
         var members = roster.Members!;
-        members.First(m => m.Name == "Danny").Status.Should().Be(MemberStatus.Active);
-        members.First(m => m.Name == "Linus").Status.Should().Be(MemberStatus.Idle);
-        members.First(m => m.Name == "Rusty").Status.Should().Be(MemberStatus.Working);
+        Assert.Equal(MemberStatus.Active, members.First(m => m.Name == "Danny").Status);
+        Assert.Equal(MemberStatus.Idle, members.First(m => m.Name == "Linus").Status);
+        Assert.Equal(MemberStatus.Working, members.First(m => m.Name == "Rusty").Status);
     }
 
     [Fact]
@@ -140,9 +140,9 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Members.Should().HaveCount(2);
-        roster.Members!.First().Name.Should().Be("Squad");
-        roster.Members!.First().Role.Should().Be("Coordinator");
+        Assert.Equal(2, roster.Members.Count);
+        Assert.Equal("Squad", roster.Members!.First().Name);
+        Assert.Equal("Coordinator", roster.Members!.First().Role);
     }
 
     [Fact]
@@ -151,8 +151,8 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Members.Should().BeNull();
-        roster.ProjectName.Should().Be("SquadTUI");
+        Assert.Null(roster.Members);
+        Assert.Equal("SquadTUI", roster.ProjectName);
     }
 
     [Fact]
@@ -171,8 +171,8 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var member = await svc.GetMemberAsync("danny");
 
-        member.Should().NotBeNull();
-        member!.Name.Should().Be("Danny");
+        Assert.NotNull(member);
+        Assert.Equal("Danny", member!.Name);
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var member = await svc.GetMemberAsync("Unknown");
 
-        member.Should().BeNull();
+        Assert.Null(member);
     }
 
     [Fact]
@@ -214,7 +214,7 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Description.Should().Be("A terminal user interface for managing AI squads");
+        Assert.Equal("A terminal user interface for managing AI squads", roster.Description);
     }
 
     [Fact]
@@ -234,8 +234,8 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Members!.First().CharterPath.Should().NotBeNull();
-        File.Exists(roster.Members!.First().CharterPath).Should().BeTrue();
+        Assert.NotNull(roster.Members!.First().CharterPath);
+        Assert.True(File.Exists(roster.Members!.First().CharterPath));
     }
 
     [Fact]
@@ -254,6 +254,6 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        roster.Members!.First().CharterPath.Should().BeNull();
+        Assert.Null(roster.Members!.First().CharterPath);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/ThemeBackgroundTests.cs
+++ b/tests/SquadTUI.Tests/Unit/ThemeBackgroundTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Hex1b.Theming;
 using SquadTUI.Themes;
 
@@ -21,7 +20,7 @@ public class ThemeBackgroundTests
     {
         var theme = ThemeManager.GetTheme(index);
         var bg = theme.Get(GlobalTheme.BackgroundColor);
-        bg.Should().NotBeNull();
+        Assert.NotNull(bg);
     }
 
     [Fact]
@@ -34,7 +33,7 @@ public class ThemeBackgroundTests
             var bg = theme.Get(GlobalTheme.BackgroundColor);
             backgrounds.Add(bg.ToBackgroundAnsi());
         }
-        backgrounds.Should().OnlyHaveUniqueItems("each theme should have a unique background color");
+        Assert.Equal(backgrounds.Distinct().Count(), backgrounds.Count());
     }
 
     [Theory]
@@ -56,7 +55,7 @@ public class ThemeBackgroundTests
 
         var bgAnsi = bg.ToBackgroundAnsi();
         var divAnsi = divider.ToBackgroundAnsi();
-        divAnsi.Should().NotBe(bgAnsi, "divider color should differ from background color");
+        Assert.NotEqual(bgAnsi, divAnsi);
     }
 
     [Theory]
@@ -79,7 +78,7 @@ public class ThemeBackgroundTests
         // Compare ANSI output — pure black would be a specific sequence
         var divAnsi = divider.ToBackgroundAnsi();
         var blackAnsi = pureBlack.ToBackgroundAnsi();
-        divAnsi.Should().NotBe(blackAnsi, "divider color should not be pure black");
+        Assert.NotEqual(blackAnsi, divAnsi);
     }
 
     [Fact]
@@ -92,7 +91,7 @@ public class ThemeBackgroundTests
             var divider = theme.Get(SplitterTheme.DividerColor);
             dividers.Add(divider.ToBackgroundAnsi());
         }
-        dividers.Should().OnlyHaveUniqueItems("each theme should have a unique divider color");
+        Assert.Equal(dividers.Distinct().Count(), dividers.Count());
     }
 
     [Theory]
@@ -108,6 +107,6 @@ public class ThemeBackgroundTests
     [InlineData(9, "Retro")]
     public void Theme_HasExpectedName(int index, string expectedName)
     {
-        ThemeManager.ThemeNames[index].Should().Be(expectedName);
+        Assert.Equal(expectedName, ThemeManager.ThemeNames[index]);
     }
 }

--- a/tests/SquadTUI.Tests/Unit/ThemeEscapeCodeLengthTests.cs
+++ b/tests/SquadTUI.Tests/Unit/ThemeEscapeCodeLengthTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Rendering;
 using SquadTUI.Themes;
 
@@ -20,8 +19,7 @@ public class ThemeEscapeCodeLengthTests
             .Select(i => ThemeManager.GetAccentCode(i).Length)
             .ToList();
 
-        lengths.Should().AllBeEquivalentTo(lengths[0],
-            "accent codes must have uniform length to prevent layout shift");
+        Assert.All(lengths, item => Assert.Equal(lengths[0], item));
     }
 
     [Fact]
@@ -31,8 +29,7 @@ public class ThemeEscapeCodeLengthTests
             .Select(i => ThemeManager.GetSecondaryAccent(i).Length)
             .ToList();
 
-        lengths.Should().AllBeEquivalentTo(lengths[0],
-            "secondary accent codes must have uniform length to prevent layout shift");
+        Assert.All(lengths, item => Assert.Equal(lengths[0], item));
     }
 
     [Fact]
@@ -42,8 +39,7 @@ public class ThemeEscapeCodeLengthTests
             .Select(i => ThemeManager.GetPanelHeaderBg(i).Length)
             .ToList();
 
-        lengths.Should().AllBeEquivalentTo(lengths[0],
-            "panel header background codes must have uniform length to prevent layout shift");
+        Assert.All(lengths, item => Assert.Equal(lengths[0], item));
     }
 
     [Fact]
@@ -53,8 +49,7 @@ public class ThemeEscapeCodeLengthTests
             .Select(i => ThemeManager.GetPanelDetailBg(i).Length)
             .ToList();
 
-        lengths.Should().AllBeEquivalentTo(lengths[0],
-            "panel detail background codes must have uniform length to prevent layout shift");
+        Assert.All(lengths, item => Assert.Equal(lengths[0], item));
     }
 
     [Fact]
@@ -63,9 +58,8 @@ public class ThemeEscapeCodeLengthTests
         for (int i = 0; i < ThemeCount; i++)
         {
             var code = ThemeManager.GetAccentCode(i);
-            code.Should().StartWith("\x1b[38;2;",
-                $"theme {ThemeManager.ThemeNames[i]} accent should use RGB foreground format");
-            code.Should().EndWith("m");
+            Assert.StartsWith("\x1b[38;2;", code);
+            Assert.EndsWith("m", code);
         }
     }
 
@@ -75,9 +69,8 @@ public class ThemeEscapeCodeLengthTests
         for (int i = 0; i < ThemeCount; i++)
         {
             var code = ThemeManager.GetSecondaryAccent(i);
-            code.Should().StartWith("\x1b[38;2;",
-                $"theme {ThemeManager.ThemeNames[i]} secondary accent should use RGB foreground format");
-            code.Should().EndWith("m");
+            Assert.StartsWith("\x1b[38;2;", code);
+            Assert.EndsWith("m", code);
         }
     }
 
@@ -88,8 +81,7 @@ public class ThemeEscapeCodeLengthTests
             .Select(i => ThemeManager.GetDimRule(i).Length)
             .ToList();
 
-        lengths.Should().AllBeEquivalentTo(lengths[0],
-            "dim rule strings must have uniform length to prevent layout shift");
+        Assert.All(lengths, item => Assert.Equal(lengths[0], item));
     }
 
     [Fact]
@@ -99,7 +91,6 @@ public class ThemeEscapeCodeLengthTests
             .Select(i => PanelRenderer.PanelTitle(i, "📈", "Test Title").Length)
             .ToList();
 
-        lengths.Should().AllBeEquivalentTo(lengths[0],
-            "panel titles must have uniform length across themes to prevent layout shift");
+        Assert.All(lengths, item => Assert.Equal(lengths[0], item));
     }
 }

--- a/tests/SquadTUI.Tests/Unit/ThemeManagerTests.cs
+++ b/tests/SquadTUI.Tests/Unit/ThemeManagerTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using SquadTUI.Themes;
 
 namespace SquadTUI.Tests.Unit;
@@ -8,7 +7,7 @@ public class ThemeManagerTests
     [Fact]
     public void ThemeNames_HasTenThemes()
     {
-        ThemeManager.ThemeNames.Should().HaveCount(10);
+        Assert.Equal(10, ThemeManager.ThemeNames.Length);
     }
 
     [Theory]
@@ -24,7 +23,7 @@ public class ThemeManagerTests
     [InlineData(9, "Retro")]
     public void ThemeNames_MatchExpectedOrder(int index, string expected)
     {
-        ThemeManager.ThemeNames[index].Should().Be(expected);
+        Assert.Equal(expected, ThemeManager.ThemeNames[index]);
     }
 
     [Theory]
@@ -41,7 +40,7 @@ public class ThemeManagerTests
     public void GetTheme_ReturnsNonNull(int index)
     {
         var theme = ThemeManager.GetTheme(index);
-        theme.Should().NotBeNull();
+        Assert.NotNull(theme);
     }
 
     [Theory]
@@ -52,22 +51,22 @@ public class ThemeManagerTests
     {
         var theme = ThemeManager.GetTheme(input);
         var expected = ThemeManager.GetTheme(expectedEquivalent);
-        theme.Should().NotBeNull();
-        expected.Should().NotBeNull();
+        Assert.NotNull(theme);
+        Assert.NotNull(expected);
     }
 
     [Fact]
     public void CreateOceanTheme_ReturnsTheme()
     {
         var theme = ThemeManager.CreateOceanTheme();
-        theme.Should().NotBeNull();
+        Assert.NotNull(theme);
     }
 
     [Fact]
     public void CreateHeistTheme_ReturnsTheme()
     {
         var theme = ThemeManager.CreateHeistTheme();
-        theme.Should().NotBeNull();
+        Assert.NotNull(theme);
     }
 
     [Theory]
@@ -84,7 +83,7 @@ public class ThemeManagerTests
     public void GetAccentCode_ReturnsNonNullString(int index)
     {
         var code = ThemeManager.GetAccentCode(index);
-        code.Should().NotBeNullOrEmpty();
+        Assert.False(string.IsNullOrEmpty(code));
     }
 
     [Theory]
@@ -101,7 +100,7 @@ public class ThemeManagerTests
     public void GetAccentCode_ReturnsAnsiEscapeCode(int index)
     {
         var code = ThemeManager.GetAccentCode(index);
-        code.Should().StartWith("\x1b[");
+        Assert.StartsWith("\x1b[", code);
     }
 
     [Theory]
@@ -113,14 +112,14 @@ public class ThemeManagerTests
     {
         var code = ThemeManager.GetAccentCode(input);
         var expected = ThemeManager.GetAccentCode(expectedEquivalent);
-        code.Should().Be(expected);
+        Assert.Equal(expected, code);
     }
 
     [Fact]
     public void GetPanelColors_ReturnsNonNull()
     {
         var colors = ThemeManager.GetPanelColors(0);
-        colors.Should().NotBeNull();
+        Assert.NotNull(colors);
     }
 
     [Fact]
@@ -129,7 +128,7 @@ public class ThemeManagerTests
         for (int i = 0; i < 10; i++)
         {
             var colors = ThemeManager.GetPanelColors(i);
-            colors.Accent.Should().Be(ThemeManager.GetAccentCode(i));
+            Assert.Equal(ThemeManager.GetAccentCode(i), colors.Accent);
         }
     }
 
@@ -141,7 +140,7 @@ public class ThemeManagerTests
     {
         // C# modulo with negative numbers may return negative, but GetTheme should handle it
         var act = () => ThemeManager.GetTheme(index);
-        act.Should().NotThrow();
+        act();
     }
 
     [Theory]
@@ -151,8 +150,8 @@ public class ThemeManagerTests
     public void GetAccentCode_VeryLargeIndex_WrapsCorrectly(int index)
     {
         var code = ThemeManager.GetAccentCode(index);
-        code.Should().NotBeNullOrEmpty();
-        code.Should().StartWith("\x1b[");
+        Assert.False(string.IsNullOrEmpty(code));
+        Assert.StartsWith("\x1b[", code);
     }
 
     [Theory]
@@ -165,8 +164,8 @@ public class ThemeManagerTests
     public void GetPanelColors_ReturnsValidForAllIndices(int index)
     {
         var colors = ThemeManager.GetPanelColors(index);
-        colors.Should().NotBeNull();
-        colors.Accent.Should().NotBeNullOrEmpty();
+        Assert.NotNull(colors);
+        Assert.False(string.IsNullOrEmpty(colors.Accent));
     }
 
     [Fact]
@@ -175,26 +174,26 @@ public class ThemeManagerTests
         var colors100 = ThemeManager.GetPanelColors(100);
         var colors0 = ThemeManager.GetPanelColors(0);
         // 100 % 10 == 0, so they should match
-        colors100.Accent.Should().Be(colors0.Accent);
+        Assert.Equal(colors0.Accent, colors100.Accent);
     }
 
     [Fact]
     public void CreateSunsetTheme_ReturnsTheme()
     {
         var theme = ThemeManager.CreateSunsetTheme();
-        theme.Should().NotBeNull();
+        Assert.NotNull(theme);
     }
 
     [Fact]
     public void CreateHighContrastTheme_ReturnsTheme()
     {
         var theme = ThemeManager.CreateHighContrastTheme();
-        theme.Should().NotBeNull();
+        Assert.NotNull(theme);
     }
 
     [Fact]
     public void AllThemes_HaveDistinctNames()
     {
-        ThemeManager.ThemeNames.Should().OnlyHaveUniqueItems();
+        Assert.Equal(ThemeManager.ThemeNames.Distinct().Count(), ThemeManager.ThemeNames.Count());
     }
 }


### PR DESCRIPTION
## Package Cleanup

### Removed
- **FluentAssertions** — replaced with xUnit `Assert.*` across 49 test files (license concerns)

### Upgraded
| Package | Old | New |
|---------|-----|-----|
| Hex1b | 0.87.0 | 0.90.0 |
| coverlet.collector | 6.0.4 | 8.0.0 |
| Microsoft.NET.Test.Sdk | 17.14.1 | 18.0.1 |
| xunit.runner.visualstudio | 3.1.4 | 3.1.5 |

### Kept (already latest)
- LanguageExt.Core 4.4.9
- NSubstitute 5.3.0 (MIT license, 32 interface mocks in 3 files — justified)
- xunit 2.9.3

### Test Results
613 tests passing, 0 failures