### PR TITLE
Sprint 16: UX Refinement — Keys, Emoji, Modal, Progress Widgets, Code Style, NSubstitute Removal

### DIFF
--- a/.ai-team/decisions/inbox/copilot-directive-sprint16-style-ux.md
+++ b/.ai-team/decisions/inbox/copilot-directive-sprint16-style-ux.md
@@ -1,0 +1,14 @@
+### 2026-02-17: User directives — Sprint 16 code style and UX
+**By:** LondoSpark (via Copilot)
+**What:**
+1. Commands should NOT be case sensitive
+2. Bring back emoji (default ON)
+3. Nice padding in tabs
+4. Settings menu should be a modal (not a separate screen) and include more than just theme
+5. Code style: use Option types instead of nullable types, abuse query expressions, prefer expression-bodied members
+6. Progress bars/confidence bars should use widgets if available, or create custom widgets
+7. GetConfidenceLevel is hardcoded — no hardcoded data in main application
+8. F1 help should show real, useful, contextual help
+9. Mouse users need buttons for hire/dismiss (not add/delete) squad members
+10. Markdown views should be scrollable with bold headings and table conversion to nice looking tables
+**Why:** User preferences for code quality, UX, and discoverability

--- a/src/SquadTUI/Models/AppSettings.cs
+++ b/src/SquadTUI/Models/AppSettings.cs
@@ -5,7 +5,7 @@ public class AppSettings
     public string ThemeName { get; set; } = "Ocean";
     public bool VimBindings { get; set; } = true;
     public bool MouseEnabled { get; set; } = true;
-    public bool ShowEmoji { get; set; } = false;
+    public bool ShowEmoji { get; set; } = true;
     public bool MarkdownRendering { get; set; } = true;
     public string DefaultScreen { get; set; } = "Dashboard";
 }

--- a/src/SquadTUI/Models/Skill.cs
+++ b/src/SquadTUI/Models/Skill.cs
@@ -1,10 +1,12 @@
+using LanguageExt;
+
 namespace SquadTUI.Models;
 
 public record Skill(
     string Name,
     string Description,
-    string? Source = null,
-    string? Confidence = null,
-    string? Content = null,
-    string? Slug = null
+    Option<string> Source = default,
+    string Confidence = "medium",
+    Option<string> Content = default,
+    Option<string> Slug = default
 );

--- a/src/SquadTUI/Models/SquadMember.cs
+++ b/src/SquadTUI/Models/SquadMember.cs
@@ -1,9 +1,11 @@
+using LanguageExt;
+
 namespace SquadTUI.Models;
 
 public record SquadMember(
     string Name,
     string Role,
     MemberStatus Status = MemberStatus.Active,
-    string? CurrentTask = null,
-    string? CharterPath = null
+    Option<string> CurrentTask = default,
+    Option<string> CharterPath = default
 );

--- a/src/SquadTUI/Models/SquadTask.cs
+++ b/src/SquadTUI/Models/SquadTask.cs
@@ -1,11 +1,13 @@
+using LanguageExt;
+
 namespace SquadTUI.Models;
 
 public record SquadTask(
     string Id,
     string Title,
-    string? Description = null,
+    Option<string> Description = default,
     SquadTaskStatus Status = SquadTaskStatus.Pending,
-    string? Assignee = null,
+    Option<string> Assignee = default,
     DateTimeOffset? StartedAt = null,
     DateTimeOffset? CompletedAt = null
 );

--- a/src/SquadTUI/Rendering/MarkdownRenderer.cs
+++ b/src/SquadTUI/Rendering/MarkdownRenderer.cs
@@ -25,14 +25,103 @@ public static class MarkdownRenderer
 
         var lines = markdown.Split('\n');
         var widgets = new List<Hex1bWidget>();
+        var i = 0;
 
-        foreach (var rawLine in lines)
+        while (i < lines.Length)
         {
-            var line = rawLine.TrimEnd('\r');
+            var line = lines[i].TrimEnd('\r');
+
+            // Detect markdown tables (lines starting with |)
+            if (line.TrimStart().StartsWith('|'))
+            {
+                var tableLines = new List<string>();
+                while (i < lines.Length && lines[i].TrimEnd('\r').TrimStart().StartsWith('|'))
+                {
+                    tableLines.Add(lines[i].TrimEnd('\r'));
+                    i++;
+                }
+                widgets.AddRange(RenderTable(ctx, tableLines));
+                continue;
+            }
+
             widgets.Add(RenderLine(ctx, line));
+            i++;
         }
 
         return widgets.ToArray();
+    }
+
+    private static Hex1bWidget[] RenderTable<T>(WidgetContext<T> ctx, List<string> tableLines) where T : Hex1bWidget
+    {
+        if (tableLines.Count == 0) return [];
+
+        // Parse rows, skipping separator lines (|---|---|)
+        var rows = new List<string[]>();
+        var separatorIndex = -1;
+        for (var i = 0; i < tableLines.Count; i++)
+        {
+            var trimmed = tableLines[i].Trim();
+            var cells = ParseTableRow(trimmed);
+            if (cells.Length > 0 && cells.All(c => c.Trim().All(ch => ch == '-' || ch == ':' || ch == ' ')))
+            {
+                separatorIndex = i;
+                continue; // skip separator
+            }
+            rows.Add(cells);
+        }
+
+        if (rows.Count == 0) return [];
+
+        // Calculate column widths
+        var colCount = rows.Max(r => r.Length);
+        var colWidths = new int[colCount];
+        foreach (var row in rows)
+        {
+            for (var c = 0; c < row.Length; c++)
+                colWidths[c] = Math.Max(colWidths[c], row[c].Trim().Length);
+        }
+
+        var widgets = new List<Hex1bWidget>();
+
+        // Top border: ┌─────┬─────┐
+        widgets.Add(ctx.Text($"  {DarkGray}┌{string.Join("┬", colWidths.Select(w => new string('─', w + 2)))}┐{Reset}"));
+
+        for (var r = 0; r < rows.Count; r++)
+        {
+            var row = rows[r];
+            var cellTexts = new string[colCount];
+            for (var c = 0; c < colCount; c++)
+            {
+                var cell = c < row.Length ? row[c].Trim() : "";
+                cellTexts[c] = cell.PadRight(colWidths[c]);
+            }
+
+            if (r == 0 && separatorIndex == 1)
+            {
+                // Header row: bold
+                widgets.Add(ctx.Text($"  {DarkGray}│{Reset} {string.Join($" {DarkGray}│{Reset} ", cellTexts.Select(c => $"{Bold}{c}{Reset}"))} {DarkGray}│{Reset}"));
+                // Header separator: ├─────┼─────┤
+                widgets.Add(ctx.Text($"  {DarkGray}├{string.Join("┼", colWidths.Select(w => new string('─', w + 2)))}┤{Reset}"));
+            }
+            else
+            {
+                // Data row
+                widgets.Add(ctx.Text($"  {DarkGray}│{Reset} {string.Join($" {DarkGray}│{Reset} ", cellTexts)} {DarkGray}│{Reset}"));
+            }
+        }
+
+        // Bottom border: └─────┴─────┘
+        widgets.Add(ctx.Text($"  {DarkGray}└{string.Join("┴", colWidths.Select(w => new string('─', w + 2)))}┘{Reset}"));
+
+        return widgets.ToArray();
+    }
+
+    private static string[] ParseTableRow(string line)
+    {
+        // Remove leading/trailing | and split
+        if (line.StartsWith('|')) line = line[1..];
+        if (line.EndsWith('|')) line = line[..^1];
+        return line.Split('|');
     }
 
     private static Hex1bWidget RenderLine<T>(WidgetContext<T> ctx, string line) where T : Hex1bWidget

--- a/src/SquadTUI/Rendering/ProgressBarRenderer.cs
+++ b/src/SquadTUI/Rendering/ProgressBarRenderer.cs
@@ -1,0 +1,55 @@
+namespace SquadTUI.Rendering;
+
+/// <summary>
+/// Renders a themed progress bar using block characters.
+/// </summary>
+public static class ProgressBarRenderer
+{
+    private const string Reset = "\x1b[0m";
+    private const string DimGray = "\x1b[90m";
+
+    /// <summary>
+    /// Renders a progress bar string for a given value between 0.0 and 1.0.
+    /// </summary>
+    /// <param name="value">Progress value from 0.0 to 1.0</param>
+    /// <param name="width">Total width in characters (default 10)</param>
+    /// <param name="filledColor">ANSI color code for the filled portion (default green)</param>
+    /// <returns>A tuple of (Bar, Label) where Label is "Low", "Medium", or "High"</returns>
+    public static (string Bar, string Label) Render(float value, int width = 10, string? filledColor = null)
+    {
+        value = Math.Clamp(value, 0f, 1f);
+        var filled = (int)Math.Round(value * width);
+        var empty = width - filled;
+
+        var color = filledColor ?? GetColorForValue(value);
+        var bar = $"{color}{new string('█', filled)}{DimGray}{new string('░', empty)}{Reset}";
+        var label = GetLabelForValue(value);
+
+        return (bar, label);
+    }
+
+    /// <summary>
+    /// Converts a confidence string ("low", "medium", "high") to a float value.
+    /// </summary>
+    public static float ConfidenceToFloat(string? confidence) => confidence?.ToLowerInvariant() switch
+    {
+        "high" => 0.8f,
+        "medium" => 0.5f,
+        "low" => 0.3f,
+        _ => 0.5f
+    };
+
+    private static string GetColorForValue(float value) => value switch
+    {
+        >= 0.7f => "\x1b[32m", // green
+        >= 0.4f => "\x1b[33m", // yellow
+        _ => "\x1b[31m"        // red
+    };
+
+    private static string GetLabelForValue(float value) => value switch
+    {
+        >= 0.7f => "High",
+        >= 0.4f => "Medium",
+        _ => "Low"
+    };
+}

--- a/src/SquadTUI/Screens/AppLayout.cs
+++ b/src/SquadTUI/Screens/AppLayout.cs
@@ -17,12 +17,12 @@ public static class AppLayout
 {
     private static (string Label, string Emoji, string Ascii, Screen Screen)[] GetTabScreens() =>
     [
-        ("  Dashboard  ", "🏠", "▸", Screen.Dashboard),
-        ("  Roster  ", "👥", "◆", Screen.Roster),
-        ("  Decisions  ", "📋", "▪", Screen.Decisions),
-        ("  Skills  ", "🔧", "◇", Screen.Skills),
-        ("  Log  ", "📊", "▪", Screen.ActivityLog),
-        ("  Metrics  ", "📈", "▪", Screen.Metrics),
+        ("   Dashboard   ", "🏠", "▸", Screen.Dashboard),
+        ("   Roster   ", "👥", "◆", Screen.Roster),
+        ("   Decisions   ", "📋", "▪", Screen.Decisions),
+        ("   Skills   ", "🔧", "◇", Screen.Skills),
+        ("   Log   ", "📊", "▪", Screen.ActivityLog),
+        ("   Metrics   ", "📈", "▪", Screen.Metrics),
     ];
 
     /// <summary>Renders a contextual status bar footer with screen-specific keybindings.</summary>
@@ -40,7 +40,7 @@ public static class AppLayout
             Screen.Skills => $"  {D}j/k: Navigate  Esc: Back  T: Theme  S: Settings  Q: Quit  F1: Help{R}",
             Screen.ActivityLog => $"  {D}j/k: Navigate  Esc: Back  T: Theme  S: Settings  Q: Quit  F1: Help{R}",
             Screen.Metrics => $"  {D}V: Toggle Burndown  Esc: Back  T: Theme  S: Settings  Q: Quit  F1: Help{R}",
-            Screen.Charter => $"  {D}Esc: Back  T: Theme  Q: Quit  F1: Help{R}",
+            Screen.Charter => $"  {D}j/k: Scroll  Esc: Back  T: Theme  Q: Quit  F1: Help{R}",
             Screen.Settings => $"  {D}j/k: Navigate  Enter: Toggle  Esc: Back  Q: Quit  F1: Help{R}",
             Screen.Help => $"  {D}F1/Esc: Dismiss  Q: Quit{R}",
             Screen.NoSquad => $"  {D}C: Create Squad  Q: Quit  F1: Help{R}",
@@ -62,6 +62,12 @@ public static class AppLayout
     {
         var em = state.Settings.ShowEmoji;
         var TabScreens = GetTabScreens();
+
+        // Settings modal overlay — renders instead of normal content
+        if (state.ShowSettingsModal)
+        {
+            return RenderSettingsModal(ctx, state, app, options);
+        }
 
         // Theme settings modal overlay — renders instead of normal content
         if (state.ShowSettingsOverlay)
@@ -252,6 +258,157 @@ public static class AppLayout
             options.Theme = ThemeManager.GetTheme(newIndex);
         }, "Up");
         keys.Key(Hex1bKey.Q).Action(() => { app.RequestStop(); }, "Quit");
+
+        // Case-insensitive: Shift+Key for uppercase input
+        keys.Shift().Key(Hex1bKey.J).Action(() =>
+        {
+            var newIndex = (state.SelectedThemeIndex + 1) % ThemeManager.ThemeNames.Length;
+            state.SelectedThemeIndex = newIndex;
+            options.Theme = ThemeManager.GetTheme(newIndex);
+        }, "Down");
+        keys.Shift().Key(Hex1bKey.K).Action(() =>
+        {
+            var newIndex = (state.SelectedThemeIndex - 1 + ThemeManager.ThemeNames.Length) % ThemeManager.ThemeNames.Length;
+            state.SelectedThemeIndex = newIndex;
+            options.Theme = ThemeManager.GetTheme(newIndex);
+        }, "Up");
+        keys.Shift().Key(Hex1bKey.Q).Action(() => { app.RequestStop(); }, "Quit");
+    }
+
+    private static readonly string[] SettingsModalLabels =
+    [
+        "Theme",
+        "Vim Keybindings",
+        "Mouse Support",
+        "Emoji Display",
+        "Markdown Rendering",
+        "Default Screen"
+    ];
+
+    private static Hex1bWidget RenderSettingsModal(
+        RootContext ctx,
+        AppState state,
+        Hex1bApp app,
+        Hex1bAppOptions options)
+    {
+        var ti = state.SelectedThemeIndex;
+        var acc = ThemeManager.GetAccentCode(ti);
+        var sec = ThemeManager.GetSecondaryAccent(ti);
+        var R = PanelRenderer.Reset;
+        var B = PanelRenderer.Bold;
+        var D = PanelRenderer.Dim;
+        var panelBg = ThemeManager.GetPanelBgColor(ti);
+        var em = state.Settings.ShowEmoji;
+        var sel = Math.Clamp(state.SettingsModalSelectedIndex, 0, SettingsModalLabels.Length - 1);
+
+        var screenNames = new[] { "Dashboard", "Roster", "Decisions", "Skills", "Log", "Metrics" };
+
+        string FormatToggle(bool v) => v ? "\x1b[32m● ON\x1b[0m" : "\x1b[90m○ OFF\x1b[0m";
+        var listItems = new List<string>
+        {
+            $"  {Icon("🎨", "◆", em)} Theme            {B}{state.Settings.ThemeName}{R}",
+            $"  {Icon("⌨️", "◆", em)}  Vim Keybindings  {FormatToggle(state.Settings.VimBindings)}",
+            $"  {Icon("🖱️", "◆", em)}  Mouse Support    {FormatToggle(state.Settings.MouseEnabled)}",
+            $"  {Icon("😀", "◆", em)} Emoji Display    {FormatToggle(state.Settings.ShowEmoji)}",
+            $"  {Icon("📝", "▪", em)} Markdown Render  {FormatToggle(state.Settings.MarkdownRendering)}",
+            $"  {Icon("🏠", "▸", em)} Default Screen   {B}{state.Settings.DefaultScreen}{R}"
+        } as IReadOnlyList<string>;
+
+        return ctx.VStack(v =>
+        [
+            v.Text(""),
+            v.Text(""),
+            new BackgroundPanelWidget(panelBg, v.VStack(modal =>
+            [
+                modal.Text($"  {B}{acc}{Icon("⚙️", "◆", em)}  Settings{R}"),
+                modal.Text($"  {sec}{new string('━', 36)}{R}"),
+                modal.Text(""),
+                modal.List(listItems)
+                    .OnSelectionChanged(e =>
+                    {
+                        state.SettingsModalSelectedIndex = e.SelectedIndex;
+                    })
+                    .OnItemActivated(e =>
+                    {
+                        ToggleSettingsModalItem(state, e.ActivatedIndex, options);
+                    })
+                    .Fill(),
+                modal.Text(""),
+                modal.Text($"  {D}j/k Navigate  Enter Toggle  Esc Close{R}"),
+                modal.Text(""),
+            ]).FillWidth(1).FillHeight()),
+        ]).WithInputBindings(keys => BindSettingsModalKeys(keys, state, app, options));
+    }
+
+    private static void ToggleSettingsModalItem(AppState state, int index, Hex1bAppOptions options)
+    {
+        var settings = state.Settings;
+        switch (index)
+        {
+            case 0: // Theme — cycle
+                var currentIdx = Array.IndexOf(ThemeManager.ThemeNames, settings.ThemeName);
+                if (currentIdx < 0) currentIdx = 0;
+                var nextIdx = (currentIdx + 1) % ThemeManager.ThemeNames.Length;
+                settings.ThemeName = ThemeManager.ThemeNames[nextIdx];
+                state.SelectedThemeIndex = nextIdx;
+                options.Theme = ThemeManager.GetTheme(nextIdx);
+                break;
+            case 1:
+                settings.VimBindings = !settings.VimBindings;
+                break;
+            case 2:
+                settings.MouseEnabled = !settings.MouseEnabled;
+                break;
+            case 3:
+                settings.ShowEmoji = !settings.ShowEmoji;
+                break;
+            case 4:
+                settings.MarkdownRendering = !settings.MarkdownRendering;
+                break;
+            case 5: // Default Screen — cycle
+                var screenNames = new[] { "Dashboard", "Roster", "Decisions", "Skills", "Log", "Metrics" };
+                var curScreenIdx = Array.IndexOf(screenNames, settings.DefaultScreen);
+                if (curScreenIdx < 0) curScreenIdx = 0;
+                settings.DefaultScreen = screenNames[(curScreenIdx + 1) % screenNames.Length];
+                break;
+        }
+        SettingsService.Save(settings);
+    }
+
+    private static void BindSettingsModalKeys(
+        InputBindingsBuilder keys,
+        AppState state,
+        Hex1bApp app,
+        Hex1bAppOptions options)
+    {
+        keys.Key(Hex1bKey.Escape).Action(() =>
+        {
+            state.ShowSettingsModal = false;
+        }, "Close");
+        keys.Key(Hex1bKey.Enter).Action(() =>
+        {
+            ToggleSettingsModalItem(state, state.SettingsModalSelectedIndex, options);
+        }, "Toggle");
+        keys.Key(Hex1bKey.J).Action(() =>
+        {
+            state.SettingsModalSelectedIndex = (state.SettingsModalSelectedIndex + 1) % SettingsModalLabels.Length;
+        }, "Down");
+        keys.Key(Hex1bKey.K).Action(() =>
+        {
+            state.SettingsModalSelectedIndex = (state.SettingsModalSelectedIndex - 1 + SettingsModalLabels.Length) % SettingsModalLabels.Length;
+        }, "Up");
+        keys.Key(Hex1bKey.Q).Action(() => { app.RequestStop(); }, "Quit");
+
+        // Case-insensitive: Shift+Key for uppercase input
+        keys.Shift().Key(Hex1bKey.J).Action(() =>
+        {
+            state.SettingsModalSelectedIndex = (state.SettingsModalSelectedIndex + 1) % SettingsModalLabels.Length;
+        }, "Down");
+        keys.Shift().Key(Hex1bKey.K).Action(() =>
+        {
+            state.SettingsModalSelectedIndex = (state.SettingsModalSelectedIndex - 1 + SettingsModalLabels.Length) % SettingsModalLabels.Length;
+        }, "Up");
+        keys.Shift().Key(Hex1bKey.Q).Action(() => { app.RequestStop(); }, "Quit");
     }
 
     private static void BindKeys(
@@ -276,8 +433,8 @@ public static class AppLayout
         {
             if (state.CurrentScreen != Screen.NoSquad)
             {
-                state.OriginalThemeIndex = state.SelectedThemeIndex;
-                state.ShowSettingsOverlay = true;
+                state.SettingsModalSelectedIndex = 0;
+                state.ShowSettingsModal = true;
             }
         }, "Settings");
         keys.Key(Hex1bKey.Escape).Action(() =>
@@ -364,6 +521,8 @@ public static class AppLayout
                 state.SkillSelectedIndex = Math.Min(state.SkillSelectedIndex + 1, (state.Skills.GetOrEmpty().Count is var sc && sc > 0 ? sc : 5) - 1);
             else if (state.CurrentScreen == Screen.Settings)
                 state.SettingsSelectedIndex = Math.Min(state.SettingsSelectedIndex + 1, 4);
+            else if (state.CurrentScreen == Screen.Charter)
+                state.CharterScrollOffset++;
         }, "Down");
         keys.Key(Hex1bKey.K).Action(() =>
         {
@@ -377,6 +536,8 @@ public static class AppLayout
                 state.SkillSelectedIndex = Math.Max(state.SkillSelectedIndex - 1, 0);
             else if (state.CurrentScreen == Screen.Settings)
                 state.SettingsSelectedIndex = Math.Max(state.SettingsSelectedIndex - 1, 0);
+            else if (state.CurrentScreen == Screen.Charter)
+                state.CharterScrollOffset = Math.Max(state.CharterScrollOffset - 1, 0);
         }, "Up");
         keys.Key(Hex1bKey.H).Action(() =>
         {
@@ -440,6 +601,154 @@ public static class AppLayout
             }
         }, "Help");
         keys.Key(Hex1bKey.V).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.Metrics)
+                state.ShowBurndown = !state.ShowBurndown;
+        }, "Toggle Burndown");
+
+        // Case-insensitive bindings: Shift+Key handles uppercase letter input
+        keys.Shift().Key(Hex1bKey.Q).Action(() => { app.RequestStop(); }, "Quit");
+        keys.Shift().Key(Hex1bKey.T).Action(() =>
+        {
+            state.SelectedThemeIndex = (state.SelectedThemeIndex + 1) % ThemeManager.ThemeNames.Length;
+            options.Theme = ThemeManager.GetTheme(state.SelectedThemeIndex);
+        }, "Theme");
+        keys.Shift().Key(Hex1bKey.S).Action(() =>
+        {
+            if (state.CurrentScreen != Screen.NoSquad)
+            {
+                state.SettingsModalSelectedIndex = 0;
+                state.ShowSettingsModal = true;
+            }
+        }, "Settings");
+        keys.Shift().Key(Hex1bKey.E).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.MemberDetail)
+                state.CurrentScreen = Screen.Charter;
+        }, "Edit Charter");
+        keys.Shift().Key(Hex1bKey.A).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.Roster && !state.ConfirmingRemove)
+            {
+                var members = state.Members.GetOrEmpty();
+                var newName = $"Member{members.Count + 1}";
+                var newRole = "Team Member";
+                state.AddMemberMessage = $"Adding {newName}...";
+                var bridge = new DataBridge(ServiceProvider.Instance);
+                _ = Task.Run(async () =>
+                {
+                    await bridge.AddMemberAsync(newName, newRole);
+                    state.Members = await bridge.LoadRosterDataAsync();
+                    state.Tasks = await bridge.LoadTasksFromRosterAsync();
+                    state.AddMemberMessage = null;
+                });
+            }
+        }, "Add Member");
+        keys.Shift().Key(Hex1bKey.D).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.Roster && !state.ConfirmingRemove)
+            {
+                state.ConfirmingRemove = true;
+            }
+        }, "Remove Member");
+        keys.Shift().Key(Hex1bKey.Y).Action(() =>
+        {
+            if (state.ConfirmingRemove && state.CurrentScreen == Screen.Roster)
+            {
+                var members = state.Members.GetOrEmpty();
+                if (members.Count > 0)
+                {
+                    var selectedIdx = Math.Clamp(state.RosterSelectedIndex, 0, members.Count - 1);
+                    var memberName = members[selectedIdx].Name;
+                    state.ConfirmingRemove = false;
+                    var bridge = new DataBridge(ServiceProvider.Instance);
+                    _ = Task.Run(async () =>
+                    {
+                        await bridge.RemoveMemberAsync(memberName);
+                        state.Members = await bridge.LoadRosterDataAsync();
+                        state.Tasks = await bridge.LoadTasksFromRosterAsync();
+                        state.RosterSelectedIndex = Math.Max(0, state.RosterSelectedIndex - 1);
+                    });
+                }
+            }
+        }, "Confirm Remove");
+        keys.Shift().Key(Hex1bKey.N).Action(() =>
+        {
+            if (state.ConfirmingRemove)
+                state.ConfirmingRemove = false;
+        }, "Cancel Remove");
+        keys.Shift().Key(Hex1bKey.J).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.Roster)
+                state.RosterSelectedIndex = Math.Min(state.RosterSelectedIndex + 1, (state.Members.GetOrEmpty().Count is var mc && mc > 0 ? mc : 6) - 1);
+            else if (state.CurrentScreen == Screen.Decisions)
+                state.DecisionSelectedIndex = Math.Min(state.DecisionSelectedIndex + 1, (state.Decisions.GetOrEmpty().Count is var dc && dc > 0 ? dc : 4) - 1);
+            else if (state.CurrentScreen == Screen.ActivityLog)
+                state.LogSelectedIndex = Math.Min(state.LogSelectedIndex + 1, (state.LogEntries.GetOrEmpty().Count is var lc && lc > 0 ? lc : 3) - 1);
+            else if (state.CurrentScreen == Screen.Skills)
+                state.SkillSelectedIndex = Math.Min(state.SkillSelectedIndex + 1, (state.Skills.GetOrEmpty().Count is var sc && sc > 0 ? sc : 5) - 1);
+            else if (state.CurrentScreen == Screen.Settings)
+                state.SettingsSelectedIndex = Math.Min(state.SettingsSelectedIndex + 1, 4);
+            else if (state.CurrentScreen == Screen.Charter)
+                state.CharterScrollOffset++;
+        }, "Down");
+        keys.Shift().Key(Hex1bKey.K).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.Roster)
+                state.RosterSelectedIndex = Math.Max(state.RosterSelectedIndex - 1, 0);
+            else if (state.CurrentScreen == Screen.Decisions)
+                state.DecisionSelectedIndex = Math.Max(state.DecisionSelectedIndex - 1, 0);
+            else if (state.CurrentScreen == Screen.ActivityLog)
+                state.LogSelectedIndex = Math.Max(state.LogSelectedIndex - 1, 0);
+            else if (state.CurrentScreen == Screen.Skills)
+                state.SkillSelectedIndex = Math.Max(state.SkillSelectedIndex - 1, 0);
+            else if (state.CurrentScreen == Screen.Settings)
+                state.SettingsSelectedIndex = Math.Max(state.SettingsSelectedIndex - 1, 0);
+            else if (state.CurrentScreen == Screen.Charter)
+                state.CharterScrollOffset = Math.Max(state.CharterScrollOffset - 1, 0);
+        }, "Up");
+        keys.Shift().Key(Hex1bKey.H).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.NoSquad) return;
+            var screens = new[] { Screen.Dashboard, Screen.Roster, Screen.Decisions, Screen.Skills, Screen.ActivityLog, Screen.Metrics };
+            var idx = Array.IndexOf(screens, state.CurrentScreen);
+            if (idx > 0) state.CurrentScreen = screens[idx - 1];
+        }, "Prev Screen");
+        keys.Shift().Key(Hex1bKey.L).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.NoSquad) return;
+            var screens = new[] { Screen.Dashboard, Screen.Roster, Screen.Decisions, Screen.Skills, Screen.ActivityLog, Screen.Metrics };
+            var idx = Array.IndexOf(screens, state.CurrentScreen);
+            if (idx >= 0 && idx < screens.Length - 1) state.CurrentScreen = screens[idx + 1];
+        }, "Next Screen");
+        keys.Shift().Key(Hex1bKey.C).Action(() =>
+        {
+            if (state.CurrentScreen == Screen.NoSquad)
+            {
+                var root = Directory.GetCurrentDirectory();
+                var fileLocations = new FileLocationService(root);
+                Directory.CreateDirectory(fileLocations.GetAgentsDirectory());
+                File.WriteAllText(fileLocations.GetRosterPath(), "# Team Roster\n\n*Created by SquadTUI*\n");
+                File.WriteAllText(fileLocations.GetDecisionsFilePath(), "# Decisions\n\n*No decisions yet.*\n");
+                state.SquadDetected = true;
+                state.SquadRootPath = root;
+                state.CurrentScreen = Screen.Dashboard;
+            }
+        }, "Create Squad");
+        keys.Shift().Key(Hex1bKey.M).Action(() =>
+        {
+            if (state.NeedsMigration && state.SquadRootPath != null)
+            {
+                var result = MigrationService.Migrate(state.SquadRootPath);
+                state.MigrationMessage = result.Message;
+                if (result.Success)
+                {
+                    state.NeedsMigration = false;
+                    ServiceProvider.Reset();
+                }
+            }
+        }, "Migrate");
+        keys.Shift().Key(Hex1bKey.V).Action(() =>
         {
             if (state.CurrentScreen == Screen.Metrics)
                 state.ShowBurndown = !state.ShowBurndown;

--- a/src/SquadTUI/Screens/AppState.cs
+++ b/src/SquadTUI/Screens/AppState.cs
@@ -51,8 +51,13 @@ public class AppState
     public bool ShowHelp { get; set; } = false;
     public bool ShowBurndown { get; set; } = false;
 
+    // Scroll offset for markdown views (Charter, etc.)
+    public int CharterScrollOffset { get; set; } = 0;
+
     // Theme modal overlay
     public bool ShowSettingsOverlay { get; set; } = false;
+    public bool ShowSettingsModal { get; set; } = false;
+    public int SettingsModalSelectedIndex { get; set; } = 0;
     public int PreviewThemeIndex { get; set; } = -1; // -1 means "use SelectedThemeIndex"
     public int OriginalThemeIndex { get; set; } = 0;
 

--- a/src/SquadTUI/Screens/CharterScreen.cs
+++ b/src/SquadTUI/Screens/CharterScreen.cs
@@ -9,6 +9,8 @@ namespace SquadTUI.Screens;
 
 public static class CharterScreen
 {
+    private const int VisibleLines = 20;
+
     public static Hex1bWidget Render(WidgetContext<VStackWidget> v, AppState state, Hex1bApp app)
     {
         var members = state.Members.GetOrEmpty();
@@ -23,6 +25,22 @@ public static class CharterScreen
         var panelBg = ThemeManager.GetPanelBgColor(state.SelectedThemeIndex);
         var em = state.Settings.ShowEmoji;
 
+        // Render all markdown lines, then slice for scrolling
+        var allWidgets = MarkdownRenderer.Render(v, charter);
+        var totalLines = allWidgets.Length;
+        var maxScroll = Math.Max(0, totalLines - VisibleLines);
+        state.CharterScrollOffset = Math.Clamp(state.CharterScrollOffset, 0, maxScroll);
+
+        var visibleWidgets = allWidgets
+            .Skip(state.CharterScrollOffset)
+            .Take(VisibleLines)
+            .ToArray();
+
+        // Scroll indicator
+        var scrollInfo = totalLines > VisibleLines
+            ? $"  {D}[{state.CharterScrollOffset + 1}–{Math.Min(state.CharterScrollOffset + VisibleLines, totalLines)}/{totalLines}] j/k to scroll{R}"
+            : "";
+
         return new BackgroundPanelWidget(panelBg, v.VStack(inner =>
         [
             inner.Text($"  {B}{acc}{Icon("📜", "▪", em)} Charter — {memberName}{R}"),
@@ -30,10 +48,10 @@ public static class CharterScreen
             inner.Text(""),
             inner.VStack(scroll =>
             [
-                ..MarkdownRenderer.Render(scroll, charter),
+                ..visibleWidgets,
             ]).Fill(),
             inner.Text(""),
-            inner.Text($"  {D}Esc Back{R}"),
+            inner.Text($"  {D}Esc Back{R}{scrollInfo}"),
         ]).Fill());
     }
 }

--- a/src/SquadTUI/Screens/DashboardScreen.cs
+++ b/src/SquadTUI/Screens/DashboardScreen.cs
@@ -1,3 +1,4 @@
+using LanguageExt;
 using Hex1b;
 using Hex1b.Widgets;
 using SquadTUI.Models;
@@ -73,7 +74,7 @@ public static class DashboardScreen
                         foreach (var m in members)
                         {
                             w.Add(left.Text($"  {GetStatusBadge(m.Status, em)} {B}{m.Name}{R}  {D}{m.Role}{R}"));
-                            var task = m.CurrentTask ?? "No active task";
+                            var task = m.CurrentTask.IfNone("No active task");
                             w.Add(left.Text($"     {D}↳ {task}{R}"));
                         }
                         w.Add(left.Text(""));

--- a/src/SquadTUI/Screens/MemberDetailScreen.cs
+++ b/src/SquadTUI/Screens/MemberDetailScreen.cs
@@ -1,3 +1,4 @@
+using LanguageExt;
 using Hex1b;
 using Hex1b.Widgets;
 using SquadTUI.Models;
@@ -26,7 +27,9 @@ public static class MemberDetailScreen
 
         var charter = state.CharterContent.Match(Some: s => s, None: () => "No charter loaded");
         var allTasks = state.Tasks.GetOrEmpty();
-        var memberTasks = allTasks.Where(t => t.Assignee == member.Name).ToList();
+        var memberTasks = (from t in allTasks
+                          where t.Assignee.Match(Some: a => a == member.Name, None: () => false)
+                          select t).ToList();
         var logs = state.LogEntries.GetOrEmpty();
         var recentLogs = logs.Where(l => l.Participants.Contains(member.Name)).Take(3).ToList();
 
@@ -48,7 +51,7 @@ public static class MemberDetailScreen
                     header.Text($"  {D}{sec}{new string('━', 44)}{R}"),
                     header.Text(""),
                     header.Text($"  {GetStatusBadge(member.Status, em)} {B}{member.Name}{R}  {D}—{R}  {member.Role}{R}"),
-                    header.Text($"  {D}Status:{R} {member.Status}    {D}Current Task:{R} {member.CurrentTask ?? $"{D}None{R}"}{R}"),
+                    header.Text($"  {D}Status:{R} {member.Status}    {D}Current Task:{R} {member.CurrentTask.IfNone($"{D}None{R}")}{R}"),
                 ]),
 
                 inner.VStack(taskSection =>
@@ -63,7 +66,7 @@ public static class MemberDetailScreen
                     };
                     if (memberTasks.Count > 0)
                         foreach (var t in memberTasks)
-                            tw.Add(taskSection.Text($"  {GetTaskBadge(t.Status, em)} {B}{t.Title}{R}  {D}{t.Description}{R}"));
+                            tw.Add(taskSection.Text($"  {GetTaskBadge(t.Status, em)} {B}{t.Title}{R}  {D}{t.Description.IfNone("")}{R}"));
                     else
                         tw.Add(taskSection.Text($"  {D}No tasks assigned{R}"));
                     return tw.ToArray();

--- a/src/SquadTUI/Screens/RosterScreen.cs
+++ b/src/SquadTUI/Screens/RosterScreen.cs
@@ -35,7 +35,9 @@ public static class RosterScreen
         var charter = state.CharterContent.Match(Some: s => s, None: () => "No charter loaded");
         var charterExcerpt = charter.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l) && !l.StartsWith('#')).Take(3);
         var allTasks = state.Tasks.GetOrEmpty();
-        var memberTasks = allTasks.Where(t => t.Assignee == selected.Name).ToList();
+        var memberTasks = (from t in allTasks
+                          where t.Assignee.Match(Some: a => a == selected.Name, None: () => false)
+                          select t).ToList();
         var logs = state.LogEntries.GetOrEmpty();
         var recentLogs = logs.Where(l => l.Participants.Contains(selected.Name)).Take(3).ToList();
         var hBg = ThemeManager.GetPanelHeaderBg(state.SelectedThemeIndex);
@@ -63,7 +65,7 @@ public static class RosterScreen
                     detail.Text(""),
                     detail.Text($"  {D}Role:{R}      {B}{selected.Role}{R}"),
                     detail.Text($"  {D}Status:{R}    {GetStatusBadge(selected.Status, em)} {selected.Status}{R}"),
-                    detail.Text($"  {D}Task:{R}      {(memberTasks.Count > 0 ? memberTasks[0].Title : selected.CurrentTask ?? $"{D}None{R}")}{R}"),
+                    detail.Text($"  {D}Task:{R}      {(memberTasks.Count > 0 ? memberTasks[0].Title : selected.CurrentTask.IfNone($"{D}None{R}"))}{R}"),
                 };
 
                 // Tasks section
@@ -75,7 +77,7 @@ public static class RosterScreen
                 if (memberTasks.Count > 0)
                 {
                     foreach (var t in memberTasks)
-                        widgets.Add(detail.Text($"  {GetTaskBadge(t.Status, em)} {t.Title}  {D}{t.Description}{R}"));
+                        widgets.Add(detail.Text($"  {GetTaskBadge(t.Status, em)} {t.Title}  {D}{t.Description.IfNone("")}{R}"));
                 }
                 else
                 {

--- a/src/SquadTUI/Screens/SkillsScreen.cs
+++ b/src/SquadTUI/Screens/SkillsScreen.cs
@@ -34,7 +34,8 @@ public static class SkillsScreen
 
         var members = state.Members.GetOrEmpty();
         var relatedMembers = GetRelatedMembers(selected.Name, members);
-        var confidence = GetConfidenceLevel(selected.Name);
+        var confidenceValue = ProgressBarRenderer.ConfidenceToFloat(selected.Confidence);
+        var confidence = ProgressBarRenderer.Render(confidenceValue);
 
         var hBg = ThemeManager.GetPanelHeaderBg(state.SelectedThemeIndex);
         var panelBg = ThemeManager.GetPanelBgColor(state.SelectedThemeIndex);
@@ -64,7 +65,7 @@ public static class SkillsScreen
                     detail.Text($"  {sec}{new string('━', 36)}{R}"),
                     detail.Text(""),
                     detail.Text($"    {D}Description:{R}  {selected.Description}{R}"),
-                    detail.Text($"    {D}Confidence:{R}   {confidence.Bar} {B}{confidence.Level}{R}"),
+                    detail.Text($"    {D}Confidence:{R}   {confidence.Bar} {B}{confidence.Label}{R}"),
                     detail.Text(""),
                     detail.Text($"  {sec}{new string('━', 36)}{R}"),
                     detail.Text(""),
@@ -91,29 +92,14 @@ public static class SkillsScreen
         ]).Fill();
     }
 
-    private static List<string> GetRelatedMembers(string skillName, IReadOnlyList<Models.SquadMember> members)
-    {
-        return skillName switch
+    private static List<string> GetRelatedMembers(string skillName, IReadOnlyList<Models.SquadMember> members) =>
+        skillName switch
         {
-            "code-review" => members.Where(m => m.Role.Contains("Dev") || m.Role.Contains("Lead")).Select(m => m.Name).ToList(),
-            "testing" => members.Where(m => m.Role.Contains("Test")).Select(m => m.Name).ToList(),
-            "documentation" => members.Where(m => m.Role.Contains("Scribe")).Select(m => m.Name).ToList(),
-            "refactoring" => members.Where(m => m.Role.Contains("Dev")).Select(m => m.Name).ToList(),
-            "debugging" => members.Where(m => m.Role.Contains("Dev") || m.Role.Contains("Test")).Select(m => m.Name).ToList(),
+            "code-review" => (from m in members where m.Role.Contains("Dev") || m.Role.Contains("Lead") select m.Name).ToList(),
+            "testing" => (from m in members where m.Role.Contains("Test") select m.Name).ToList(),
+            "documentation" => (from m in members where m.Role.Contains("Scribe") select m.Name).ToList(),
+            "refactoring" => (from m in members where m.Role.Contains("Dev") select m.Name).ToList(),
+            "debugging" => (from m in members where m.Role.Contains("Dev") || m.Role.Contains("Test") select m.Name).ToList(),
             _ => []
         };
-    }
-
-    private static (string Bar, string Level) GetConfidenceLevel(string skillName)
-    {
-        return skillName switch
-        {
-            "code-review" => ("\x1b[32m████████\x1b[90m░░\x1b[0m", "High"),
-            "testing" => ("\x1b[32m███████\x1b[90m░░░\x1b[0m", "High"),
-            "documentation" => ("\x1b[33m██████\x1b[90m░░░░\x1b[0m", "Medium"),
-            "refactoring" => ("\x1b[33m█████\x1b[90m░░░░░\x1b[0m", "Medium"),
-            "debugging" => ("\x1b[32m████████\x1b[90m░░\x1b[0m", "High"),
-            _ => ("\x1b[33m████\x1b[90m░░░░░░\x1b[0m", "Medium")
-        };
-    }
 }

--- a/src/SquadTUI/Services/DataBridge.cs
+++ b/src/SquadTUI/Services/DataBridge.cs
@@ -41,12 +41,10 @@ public class DataBridge
             var idx = 1;
             foreach (var m in members)
             {
-                var taskTitle = m.CurrentTask;
-
-                // Try to get task from agent history/inbox if not set on member
-                var resolvedTitle = taskTitle.Match(
-                    Some: t => t,
-                    None: () => currentTasks.TryGetValue(m.Name, out var fromHistory) ? fromHistory : null);
+                // Resolve task title: prefer member's current task, fall back to history
+                string? resolvedTitle = m.CurrentTask.IsSome
+                    ? (string)m.CurrentTask
+                    : currentTasks.TryGetValue(m.Name, out var fromHistory) ? fromHistory : null;
 
                 if (!string.IsNullOrEmpty(resolvedTitle))
                 {

--- a/src/SquadTUI/Services/DataBridge.cs
+++ b/src/SquadTUI/Services/DataBridge.cs
@@ -13,10 +13,8 @@ public class DataBridge
         _services = services;
     }
 
-    public async Task<DashboardData> LoadDashboardDataAsync(CancellationToken ct = default)
-    {
-        return await _services.SquadData.GetDashboardAsync(ct);
-    }
+    public async Task<DashboardData> LoadDashboardDataAsync(CancellationToken ct = default) =>
+        await _services.SquadData.GetDashboardAsync(ct);
 
     public async Task<Either<AppError, IReadOnlyList<SquadMember>>> LoadRosterDataAsync(CancellationToken ct = default)
     {
@@ -37,7 +35,8 @@ public class DataBridge
         {
             var roster = await _services.Team.GetRosterAsync(ct);
             var members = roster.Members ?? [];
-            var currentTasks = await _services.Team.GetCurrentTasksAsync(ct);
+            var currentTasks = await _services.Team.GetCurrentTasksAsync(ct)
+                ?? (IReadOnlyDictionary<string, string>)new Dictionary<string, string>();
             var tasks = new List<SquadTask>();
             var idx = 1;
             foreach (var m in members)
@@ -45,13 +44,11 @@ public class DataBridge
                 var taskTitle = m.CurrentTask;
 
                 // Try to get task from agent history/inbox if not set on member
-                if (string.IsNullOrEmpty(taskTitle) &&
-                    currentTasks.TryGetValue(m.Name, out var fromHistory))
-                {
-                    taskTitle = fromHistory;
-                }
+                var resolvedTitle = taskTitle.Match(
+                    Some: t => t,
+                    None: () => currentTasks.TryGetValue(m.Name, out var fromHistory) ? fromHistory : null);
 
-                if (!string.IsNullOrEmpty(taskTitle))
+                if (!string.IsNullOrEmpty(resolvedTitle))
                 {
                     var status = m.Status switch
                     {
@@ -60,7 +57,7 @@ public class DataBridge
                         MemberStatus.Idle => SquadTaskStatus.Pending,
                         _ => SquadTaskStatus.Pending
                     };
-                    tasks.Add(new SquadTask($"task-{idx}", taskTitle, null, status, m.Name));
+                    tasks.Add(new SquadTask($"task-{idx}", resolvedTitle, default, status, m.Name));
                 }
                 idx++;
             }
@@ -113,10 +110,12 @@ public class DataBridge
         try
         {
             var member = await _services.Team.GetMemberAsync(memberName, ct);
-            if (member?.CharterPath == null || !File.Exists(member.CharterPath))
+            if (member == null)
                 return None;
-
-            return Some(await File.ReadAllTextAsync(member.CharterPath, ct));
+            var charterPath = member.CharterPath.Where(File.Exists);
+            return charterPath.IsSome
+                ? Some(await File.ReadAllTextAsync((string)charterPath, ct))
+                : None;
         }
         catch
         {

--- a/src/SquadTUI/Services/SkillService.cs
+++ b/src/SquadTUI/Services/SkillService.cs
@@ -1,3 +1,5 @@
+using LanguageExt;
+using static LanguageExt.Prelude;
 using SquadTUI.Models;
 
 namespace SquadTUI.Services;
@@ -53,8 +55,8 @@ public class SkillService : ISkillService
         var lines = content.Split('\n');
         string? name = null;
         string? description = null;
-        string? source = null;
-        string? confidence = null;
+        Option<string> source = None;
+        string confidence = "medium";
 
         var inFrontmatter = false;
         var bodyLines = new List<string>();
@@ -86,7 +88,7 @@ public class SkillService : ISkillService
                     {
                         case "name": name = value; break;
                         case "description": description = value; break;
-                        case "source": source = value; break;
+                        case "source": source = Some(value); break;
                         case "confidence": confidence = value; break;
                     }
                 }
@@ -108,6 +110,8 @@ public class SkillService : ISkillService
 
         var bodyContent = string.Join('\n', bodyLines).Trim();
 
-        return new Skill(name, description, source, confidence, bodyContent, slug);
+        return new Skill(name, description, source, confidence,
+            string.IsNullOrEmpty(bodyContent) ? None : Some(bodyContent),
+            Some(slug));
     }
 }

--- a/src/SquadTUI/Services/TeamService.cs
+++ b/src/SquadTUI/Services/TeamService.cs
@@ -1,3 +1,5 @@
+using LanguageExt;
+using static LanguageExt.Prelude;
 using SquadTUI.Models;
 
 namespace SquadTUI.Services;
@@ -146,14 +148,15 @@ public class TeamService : ITeamService
     public async Task<SquadMember?> GetMemberAsync(string name, CancellationToken ct = default)
     {
         var roster = await GetRosterAsync(ct);
-        return roster.Members?.FirstOrDefault(m =>
-            m.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return (from m in roster.Members ?? []
+                where m.Name.Equals(name, StringComparison.OrdinalIgnoreCase)
+                select m).FirstOrDefault();
     }
 
-    private string? GetCharterPath(string memberName)
+    private Option<string> GetCharterPath(string memberName)
     {
         var charterFile = _fileLocations.GetCharterPath(memberName);
-        return File.Exists(charterFile) ? charterFile : null;
+        return File.Exists(charterFile) ? Some(charterFile) : None;
     }
 
     public async Task<IReadOnlyDictionary<string, string>> GetCurrentTasksAsync(CancellationToken ct = default)
@@ -348,10 +351,8 @@ public class TeamService : ITeamService
             Directory.Delete(agentDir, true);
     }
 
-    private static MemberStatus ParseMemberStatus(string text)
-    {
-        var cleaned = text.Replace("✅", "").Replace("📋", "").Replace("🔄", "").Trim().ToLowerInvariant();
-        return cleaned switch
+    private static MemberStatus ParseMemberStatus(string text) =>
+        text.Replace("✅", "").Replace("📋", "").Replace("🔄", "").Trim().ToLowerInvariant() switch
         {
             "active" => MemberStatus.Active,
             "idle" => MemberStatus.Idle,
@@ -361,7 +362,6 @@ public class TeamService : ITeamService
             "monitor" => MemberStatus.Active,
             _ => MemberStatus.Active
         };
-    }
 
     private static List<string> ParseTableRow(string line)
     {

--- a/tests/SquadTUI.Tests/E2E/AppNavigationTests.cs
+++ b/tests/SquadTUI.Tests/E2E/AppNavigationTests.cs
@@ -223,7 +223,7 @@ public class AppNavigationTests
     }
 
     [Fact]
-    public async Task PressS_OpensThemeModal()
+    public async Task PressS_OpensSettingsModal()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -237,7 +237,7 @@ public class AppNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Settings"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/SettingsNavigationTests.cs
+++ b/tests/SquadTUI.Tests/E2E/SettingsNavigationTests.cs
@@ -8,7 +8,7 @@ namespace SquadTUI.Tests.E2E;
 public class SettingsNavigationTests
 {
     [Fact]
-    public async Task PressS_OpensThemeModal()
+    public async Task PressS_OpensSettingsModal()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -22,14 +22,14 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Settings"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task EscapeFromThemeModal_ReturnsToDashboard()
+    public async Task EscapeFromSettingsModal_ReturnsToDashboard()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -52,7 +52,7 @@ public class SettingsNavigationTests
     }
 
     [Fact]
-    public async Task ThemeModal_ShowsThemeOption()
+    public async Task SettingsModal_ShowsThemeOption()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -73,7 +73,7 @@ public class SettingsNavigationTests
     }
 
     [Fact]
-    public async Task ThemeModal_ShowsAllThemeNames()
+    public async Task SettingsModal_ShowsAllSettings()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -87,14 +87,14 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Heist"));
+        Assert.True(snapshot.ContainsText("Vim Keybindings"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task ThemeModal_ShowsNavigationHints()
+    public async Task SettingsModal_ShowsNavigationHints()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -115,7 +115,7 @@ public class SettingsNavigationTests
     }
 
     [Fact]
-    public async Task ThemeModal_ShowsConfirmCancel()
+    public async Task SettingsModal_ShowsToggleClose()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -129,15 +129,15 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Confirm"));
-        Assert.True(snapshot.ContainsText("Cancel"));
+        Assert.True(snapshot.ContainsText("Toggle"));
+        Assert.True(snapshot.ContainsText("Close"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task ThemeModal_At80Cols_ShowsThemeContent()
+    public async Task SettingsModal_At80Cols_ShowsContent()
     {
         await using var terminal = TestAppBuilder.Build(width: 80, height: 30);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -151,7 +151,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Settings"));
         Assert.True(snapshot.ContainsText("Ocean"));
 
         cts.Cancel();
@@ -159,7 +159,7 @@ public class SettingsNavigationTests
     }
 
     [Fact]
-    public async Task ThemeModal_At60Cols_ShowsThemeContent()
+    public async Task SettingsModal_At60Cols_ShowsContent()
     {
         await using var terminal = TestAppBuilder.Build(width: 60, height: 30);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -173,7 +173,7 @@ public class SettingsNavigationTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Settings"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/E2E/ThemeModalTests.cs
+++ b/tests/SquadTUI.Tests/E2E/ThemeModalTests.cs
@@ -8,7 +8,7 @@ namespace SquadTUI.Tests.E2E;
 public class ThemeModalTests
 {
     [Fact]
-    public async Task PressS_OpensThemeModal()
+    public async Task PressS_OpensSettingsModal()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -22,14 +22,14 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Theme Selection"));
+        Assert.True(snapshot.ContainsText("Settings"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task ThemeModal_ShowsThemeList()
+    public async Task SettingsModal_ShowsSettingsList()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -44,15 +44,15 @@ public class ThemeModalTests
 
         var snapshot = terminal.CreateSnapshot();
         Assert.True(snapshot.ContainsText("Ocean"));
-        Assert.True(snapshot.ContainsText("Heist"));
-        Assert.True(snapshot.ContainsText("Sunset"));
+        Assert.True(snapshot.ContainsText("Vim Keybindings"));
+        Assert.True(snapshot.ContainsText("Emoji Display"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task ThemeModal_EscapeClosesModal()
+    public async Task SettingsModal_EscapeClosesModal()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -68,7 +68,7 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.False(snapshot.ContainsText("Theme Selection"));
+        Assert.False(snapshot.ContainsText("Vim Keybindings"));
         Assert.True(snapshot.ContainsText("Dashboard"));
 
         cts.Cancel();
@@ -76,7 +76,7 @@ public class ThemeModalTests
     }
 
     [Fact]
-    public async Task ThemeModal_ShowsNavigationHints()
+    public async Task SettingsModal_ShowsNavigationHints()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -91,15 +91,15 @@ public class ThemeModalTests
 
         var snapshot = terminal.CreateSnapshot();
         Assert.True(snapshot.ContainsText("Navigate"));
-        Assert.True(snapshot.ContainsText("Confirm"));
-        Assert.True(snapshot.ContainsText("Cancel"));
+        Assert.True(snapshot.ContainsText("Toggle"));
+        Assert.True(snapshot.ContainsText("Close"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task ThemeModal_EnterConfirmsAndCloses()
+    public async Task SettingsModal_EnterTogglesAndStaysOpen()
     {
         await using var terminal = TestAppBuilder.Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -115,8 +115,8 @@ public class ThemeModalTests
         await Task.Delay(200);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.False(snapshot.ContainsText("Theme Selection"));
-        Assert.True(snapshot.ContainsText("Dashboard"));
+        // Settings modal stays open after toggling
+        Assert.True(snapshot.ContainsText("Settings"));
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/SquadTUI.Tests/ErrorHandlingTests.cs
+++ b/tests/SquadTUI.Tests/ErrorHandlingTests.cs
@@ -1,10 +1,9 @@
 using LanguageExt;
 using static LanguageExt.Prelude;
-using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using SquadTUI.Models;
 using SquadTUI.Screens;
 using SquadTUI.Services;
+using SquadTUI.Tests.Stubs;
 
 namespace SquadTUI.Tests;
 
@@ -147,11 +146,8 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadRoster_ReturnsLeft_WhenServiceThrows()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("disk error"));
-
-        var sp = CreateServiceProvider(teamService: teamService);
+        var teamService = new StubTeamService { RosterException = new InvalidOperationException("disk error") };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
@@ -168,14 +164,14 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadRoster_ReturnsRight_OnSuccess()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .Returns(new TeamRoster("TestProject", Members: new List<SquadMember>
+        var teamService = new StubTeamService
+        {
+            RosterResult = new TeamRoster("TestProject", Members: new List<SquadMember>
             {
                 new("Alice", "Dev", MemberStatus.Active),
-            }));
-
-        var sp = CreateServiceProvider(teamService: teamService);
+            })
+        };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
@@ -188,11 +184,8 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadDecisions_ReturnsLeft_WhenServiceThrows()
     {
-        var decisionService = Substitute.For<IDecisionService>();
-        decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new IOException("file locked"));
-
-        var sp = CreateServiceProvider(decisionService: decisionService);
+        var decisionService = new StubDecisionService { Exception = new IOException("file locked") };
+        var sp = StubServiceProviderFactory.Create(decisions: decisionService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadDecisionsDataAsync();
@@ -202,14 +195,11 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadDecisions_ReturnsRight_OnSuccess()
     {
-        var decisionService = Substitute.For<IDecisionService>();
-        decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>())
-            .Returns(new List<DecisionEntry>
-            {
-                new("Use REST", "2026-03-01", "Alice", "REST chosen"),
-            });
-
-        var sp = CreateServiceProvider(decisionService: decisionService);
+        var decisionService = new StubDecisionService
+        {
+            Result = new List<DecisionEntry> { new("Use REST", "2026-03-01", "Alice", "REST chosen") }
+        };
+        var sp = StubServiceProviderFactory.Create(decisions: decisionService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadDecisionsDataAsync();
@@ -220,11 +210,8 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadSkills_ReturnsLeft_WhenServiceThrows()
     {
-        var skillService = Substitute.For<ISkillService>();
-        skillService.GetSkillsAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("parse error"));
-
-        var sp = CreateServiceProvider(skillService: skillService);
+        var skillService = new StubSkillService { Exception = new Exception("parse error") };
+        var sp = StubServiceProviderFactory.Create(skills: skillService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadSkillsDataAsync();
@@ -234,11 +221,8 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadLog_ReturnsLeft_WhenServiceThrows()
     {
-        var logService = Substitute.For<IOrchestrationLogService>();
-        logService.GetEntriesAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("log error"));
-
-        var sp = CreateServiceProvider(logService: logService);
+        var logService = new StubOrchestrationLogService { Exception = new Exception("log error") };
+        var sp = StubServiceProviderFactory.Create(log: logService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadLogDataAsync();
@@ -248,11 +232,8 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadTasks_ReturnsLeft_WhenServiceThrows()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("roster unavailable"));
-
-        var sp = CreateServiceProvider(teamService: teamService);
+        var teamService = new StubTeamService { RosterException = new Exception("roster unavailable") };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadTasksFromRosterAsync();
@@ -262,18 +243,19 @@ public class ErrorHandlingTests
     [Fact]
     public async Task DataBridge_LoadTasks_MapsStatusCorrectly()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .Returns(new TeamRoster("Test", Members: new List<SquadMember>
+        var teamService = new StubTeamService
+        {
+            RosterResult = new TeamRoster("Test", Members: new List<SquadMember>
             {
                 new("A", "Dev", MemberStatus.Working, "task-working"),
                 new("B", "Dev", MemberStatus.Active, "task-active"),
                 new("C", "Dev", MemberStatus.Idle, "task-idle"),
                 new("D", "Dev", MemberStatus.Offline, "task-offline"),
                 new("E", "Dev", MemberStatus.Active), // no current task — should be skipped
-            }));
-
-        var sp = CreateServiceProvider(teamService: teamService);
+            }),
+            CurrentTasksResult = new Dictionary<string, string>()
+        };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadTasksFromRosterAsync();
@@ -349,22 +331,4 @@ public class ErrorHandlingTests
 
     #endregion
 
-    #region Helpers
-
-    private static ServiceProvider CreateServiceProvider(
-        ITeamService? teamService = null,
-        IDecisionService? decisionService = null,
-        ISkillService? skillService = null,
-        IOrchestrationLogService? logService = null)
-    {
-        teamService ??= Substitute.For<ITeamService>();
-        decisionService ??= Substitute.For<IDecisionService>();
-        skillService ??= Substitute.For<ISkillService>();
-        logService ??= Substitute.For<IOrchestrationLogService>();
-
-        var squadData = Substitute.For<ISquadDataProvider>();
-        return new ServiceProvider(squadData, teamService, decisionService, skillService, logService);
-    }
-
-    #endregion
 }

--- a/tests/SquadTUI.Tests/Fixtures/SampleData.cs
+++ b/tests/SquadTUI.Tests/Fixtures/SampleData.cs
@@ -1,3 +1,5 @@
+using LanguageExt;
+using static LanguageExt.Prelude;
 using SquadTUI.Models;
 
 namespace SquadTUI.Tests.Fixtures;
@@ -6,11 +8,11 @@ public static class SampleData
 {
     public static readonly IReadOnlyList<SquadMember> Members =
     [
-        new("Sonic", "Lead", MemberStatus.Active, "Architecture planning"),
-        new("Tails", "Frontend/TUI Dev", MemberStatus.Active, "Building TUI screens"),
-        new("Knuckles", "Backend Dev", MemberStatus.Active, "Service implementations"),
-        new("Amy", "Tester", MemberStatus.Active, "Writing test suite"),
-        new("Shadow", "UX/Design", MemberStatus.Active, "Navigation design"),
+        new("Sonic", "Lead", MemberStatus.Active, Some("Architecture planning")),
+        new("Tails", "Frontend/TUI Dev", MemberStatus.Active, Some("Building TUI screens")),
+        new("Knuckles", "Backend Dev", MemberStatus.Active, Some("Service implementations")),
+        new("Amy", "Tester", MemberStatus.Active, Some("Writing test suite")),
+        new("Shadow", "UX/Design", MemberStatus.Active, Some("Navigation design")),
         new("Eggman", "Eggman", MemberStatus.Idle),
     ];
 
@@ -56,11 +58,11 @@ public static class SampleData
 
     public static readonly IReadOnlyList<SquadTask> Tasks =
     [
-        new("task-1", "Build TUI screens", "Create all screen components", SquadTaskStatus.InProgress, "Tails"),
-        new("task-2", "Implement services", "Build data provider services", SquadTaskStatus.InProgress, "Knuckles"),
-        new("task-3", "Write test suite", "Automated tests for all components", SquadTaskStatus.Pending, "Amy"),
-        new("task-4", "UX review", "Review navigation flow", SquadTaskStatus.Done, "Shadow"),
-        new("task-5", "Architecture doc", "Document system architecture", SquadTaskStatus.Done, "Sonic"),
+        new("task-1", "Build TUI screens", Some("Create all screen components"), SquadTaskStatus.InProgress, Some("Tails")),
+        new("task-2", "Implement services", Some("Build data provider services"), SquadTaskStatus.InProgress, Some("Knuckles")),
+        new("task-3", "Write test suite", Some("Automated tests for all components"), SquadTaskStatus.Pending, Some("Amy")),
+        new("task-4", "UX review", Some("Review navigation flow"), SquadTaskStatus.Done, Some("Shadow")),
+        new("task-5", "Architecture doc", Some("Document system architecture"), SquadTaskStatus.Done, Some("Sonic")),
     ];
 
     // --- Sprint velocity history (3 sprints, Sonic themed) ---

--- a/tests/SquadTUI.Tests/Integration/SkillServiceIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/SkillServiceIntegrationTests.cs
@@ -1,3 +1,5 @@
+using LanguageExt;
+using static LanguageExt.Prelude;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Integration;
@@ -25,9 +27,9 @@ public class SkillServiceIntegrationTests
         var skill = skills.First();
         Assert.Equal("test-skill", skill.Name);
         Assert.Equal("A skill for testing purposes", skill.Description);
-        Assert.Equal("manual", skill.Source);
+        Assert.Equal(Some("manual"), skill.Source);
         Assert.Equal("high", skill.Confidence);
-        Assert.Equal("test-skill", skill.Slug);
+        Assert.Equal(Some("test-skill"), skill.Slug);
     }
 
     [Fact]
@@ -36,7 +38,7 @@ public class SkillServiceIntegrationTests
         var svc = new SkillService(GetFixturesPath());
         var skills = await svc.GetSkillsAsync();
 
-        Assert.Contains("integration tests", skills.First().Content);
+        Assert.Contains("integration tests", skills.First().Content.IfNone(""));
     }
 
     [Fact]

--- a/tests/SquadTUI.Tests/Integration/TeamServiceIntegrationTests.cs
+++ b/tests/SquadTUI.Tests/Integration/TeamServiceIntegrationTests.cs
@@ -1,3 +1,4 @@
+using LanguageExt;
 using SquadTUI.Models;
 using SquadTUI.Services;
 
@@ -69,8 +70,8 @@ public class TeamServiceIntegrationTests
         var roster = await svc.GetRosterAsync();
 
         var danny = roster.Members!.First(m => m.Name == "Danny");
-        Assert.NotNull(danny.CharterPath);
-        Assert.True(File.Exists(danny.CharterPath));
+        Assert.True(danny.CharterPath.IsSome);
+        danny.CharterPath.IfSome(p => Assert.True(File.Exists(p)));
     }
 
     [Fact]

--- a/tests/SquadTUI.Tests/IntegrationTests.cs
+++ b/tests/SquadTUI.Tests/IntegrationTests.cs
@@ -1,10 +1,9 @@
 using LanguageExt;
 using static LanguageExt.Prelude;
-using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using SquadTUI.Models;
 using SquadTUI.Screens;
 using SquadTUI.Services;
+using SquadTUI.Tests.Stubs;
 using SquadTUI.Themes;
 
 namespace SquadTUI.Tests;
@@ -19,23 +18,12 @@ public class IntegrationTests
     [Fact]
     public async Task DataBridge_AllLoads_ReturnLeft_WhenAllServicesThrow()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("team fail"));
+        var teamService = new StubTeamService { RosterException = new Exception("team fail") };
+        var decisionService = new StubDecisionService { Exception = new Exception("decision fail") };
+        var skillService = new StubSkillService { Exception = new Exception("skill fail") };
+        var logService = new StubOrchestrationLogService { Exception = new Exception("log fail") };
 
-        var decisionService = Substitute.For<IDecisionService>();
-        decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("decision fail"));
-
-        var skillService = Substitute.For<ISkillService>();
-        skillService.GetSkillsAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("skill fail"));
-
-        var logService = Substitute.For<IOrchestrationLogService>();
-        logService.GetEntriesAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("log fail"));
-
-        var sp = CreateServiceProvider(teamService, decisionService, skillService, logService);
+        var sp = StubServiceProviderFactory.Create(teamService, decisionService, skillService, logService);
         var bridge = new DataBridge(sp);
 
         var roster = await bridge.LoadRosterDataAsync();
@@ -54,15 +42,13 @@ public class IntegrationTests
     [Fact]
     public async Task DataBridge_PartialFailure_OtherDataStillAvailable()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("team fail"));
+        var teamService = new StubTeamService { RosterException = new Exception("team fail") };
+        var decisionService = new StubDecisionService
+        {
+            Result = new List<DecisionEntry> { new("Decision1", "2026-03-01", "Alice", "Details") }
+        };
 
-        var decisionService = Substitute.For<IDecisionService>();
-        decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>())
-            .Returns(new List<DecisionEntry> { new("Decision1", "2026-03-01", "Alice", "Details") });
-
-        var sp = CreateServiceProvider(teamService: teamService, decisionService: decisionService);
+        var sp = StubServiceProviderFactory.Create(team: teamService, decisions: decisionService);
         var bridge = new DataBridge(sp);
 
         var roster = await bridge.LoadRosterDataAsync();
@@ -76,11 +62,8 @@ public class IntegrationTests
     [Fact]
     public async Task DataBridge_CharterContent_ReturnsNone_WhenMemberNotFound()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetMemberAsync("nobody", Arg.Any<CancellationToken>())
-            .Returns((SquadMember?)null);
-
-        var sp = CreateServiceProvider(teamService: teamService);
+        var teamService = new StubTeamService { MemberResult = null };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadCharterContentAsync("nobody");
@@ -90,11 +73,8 @@ public class IntegrationTests
     [Fact]
     public async Task DataBridge_CharterContent_ReturnsNone_WhenServiceThrows()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetMemberAsync("crash", Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("crash"));
-
-        var sp = CreateServiceProvider(teamService: teamService);
+        var teamService = new StubTeamService { MemberException = new Exception("crash") };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadCharterContentAsync("crash");
@@ -104,11 +84,11 @@ public class IntegrationTests
     [Fact]
     public async Task DataBridge_LoadRoster_EmptyRoster_ReturnsRightEmptyList()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .Returns(new TeamRoster("Empty", Members: new List<SquadMember>()));
-
-        var sp = CreateServiceProvider(teamService: teamService);
+        var teamService = new StubTeamService
+        {
+            RosterResult = new TeamRoster("Empty", Members: new List<SquadMember>())
+        };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
@@ -119,11 +99,11 @@ public class IntegrationTests
     [Fact]
     public async Task DataBridge_LoadRoster_NullMembers_ReturnsRightEmptyList()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetRosterAsync(Arg.Any<CancellationToken>())
-            .Returns(new TeamRoster("NullMembers"));
-
-        var sp = CreateServiceProvider(teamService: teamService);
+        var teamService = new StubTeamService
+        {
+            RosterResult = new TeamRoster("NullMembers")
+        };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.LoadRosterDataAsync();
@@ -286,22 +266,4 @@ public class IntegrationTests
 
     #endregion
 
-    #region Helpers
-
-    private static ServiceProvider CreateServiceProvider(
-        ITeamService? teamService = null,
-        IDecisionService? decisionService = null,
-        ISkillService? skillService = null,
-        IOrchestrationLogService? logService = null)
-    {
-        teamService ??= Substitute.For<ITeamService>();
-        decisionService ??= Substitute.For<IDecisionService>();
-        skillService ??= Substitute.For<ISkillService>();
-        logService ??= Substitute.For<IOrchestrationLogService>();
-
-        var squadData = Substitute.For<ISquadDataProvider>();
-        return new ServiceProvider(squadData, teamService, decisionService, skillService, logService);
-    }
-
-    #endregion
 }

--- a/tests/SquadTUI.Tests/SampleDataLeakTests.cs
+++ b/tests/SquadTUI.Tests/SampleDataLeakTests.cs
@@ -67,8 +67,8 @@ public class SampleDataLeakTests
     {
         var state = CreateStateWithRealData();
         var assignees = state.Tasks.GetOrEmpty()
-            .Where(t => t.Assignee != null)
-            .Select(t => t.Assignee!)
+            .Where(t => t.Assignee.IsSome)
+            .Select(t => t.Assignee.IfNone(""))
             .ToList();
 
         foreach (var sampleName in SampleDataNames)

--- a/tests/SquadTUI.Tests/SquadTUI.Tests.csproj
+++ b/tests/SquadTUI.Tests/SquadTUI.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Hex1b" Version="0.90.0" />
     <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/SquadTUI.Tests/Stubs/StubServices.cs
+++ b/tests/SquadTUI.Tests/Stubs/StubServices.cs
@@ -1,0 +1,129 @@
+using LanguageExt;
+using SquadTUI.Models;
+using SquadTUI.Services;
+
+namespace SquadTUI.Tests.Stubs;
+
+/// <summary>Hand-written stubs replacing NSubstitute. Each stub can be configured
+/// with return values or exceptions to throw.</summary>
+
+public class StubTeamService : ITeamService
+{
+    public TeamRoster? RosterResult { get; set; }
+    public Exception? RosterException { get; set; }
+    public SquadMember? MemberResult { get; set; }
+    public Exception? MemberException { get; set; }
+    public IReadOnlyDictionary<string, string>? CurrentTasksResult { get; set; }
+    public Exception? CurrentTasksException { get; set; }
+    public Exception? AddMemberException { get; set; }
+    public Exception? RemoveMemberException { get; set; }
+
+    public Task<TeamRoster> GetRosterAsync(CancellationToken ct = default) =>
+        RosterException is not null
+            ? throw RosterException
+            : Task.FromResult(RosterResult ?? new TeamRoster("Stub"));
+
+    public Task<SquadMember?> GetMemberAsync(string name, CancellationToken ct = default) =>
+        MemberException is not null
+            ? throw MemberException
+            : Task.FromResult(MemberResult);
+
+    public Task<IReadOnlyDictionary<string, string>> GetCurrentTasksAsync(CancellationToken ct = default) =>
+        CurrentTasksException is not null
+            ? throw CurrentTasksException
+            : Task.FromResult(CurrentTasksResult
+                ?? (IReadOnlyDictionary<string, string>)new Dictionary<string, string>());
+
+    public Task AddMemberAsync(string name, string role, CancellationToken ct = default) =>
+        AddMemberException is not null
+            ? throw AddMemberException
+            : Task.CompletedTask;
+
+    public Task RemoveMemberAsync(string name, CancellationToken ct = default) =>
+        RemoveMemberException is not null
+            ? throw RemoveMemberException
+            : Task.CompletedTask;
+}
+
+public class StubDecisionService : IDecisionService
+{
+    public IReadOnlyList<DecisionEntry>? Result { get; set; }
+    public Exception? Exception { get; set; }
+
+    public Task<IReadOnlyList<DecisionEntry>> GetDecisionsAsync(CancellationToken ct = default) =>
+        Exception is not null
+            ? throw Exception
+            : Task.FromResult(Result ?? (IReadOnlyList<DecisionEntry>)[]);
+}
+
+public class StubSkillService : ISkillService
+{
+    public IReadOnlyList<Skill>? Result { get; set; }
+    public Exception? Exception { get; set; }
+    public Skill? SingleResult { get; set; }
+
+    public Task<IReadOnlyList<Skill>> GetSkillsAsync(CancellationToken ct = default) =>
+        Exception is not null
+            ? throw Exception
+            : Task.FromResult(Result ?? (IReadOnlyList<Skill>)[]);
+
+    public Task<Skill?> GetSkillAsync(string slug, CancellationToken ct = default) =>
+        Task.FromResult(SingleResult);
+}
+
+public class StubOrchestrationLogService : IOrchestrationLogService
+{
+    public IReadOnlyList<OrchestrationLogEntry>? Result { get; set; }
+    public Exception? Exception { get; set; }
+
+    public Task<IReadOnlyList<OrchestrationLogEntry>> GetEntriesAsync(CancellationToken ct = default) =>
+        Exception is not null
+            ? throw Exception
+            : Task.FromResult(Result ?? (IReadOnlyList<OrchestrationLogEntry>)[]);
+
+    public Task<IReadOnlyList<OrchestrationLogEntry>> GetEntriesByDateAsync(string date, CancellationToken ct = default) =>
+        Task.FromResult(Result ?? (IReadOnlyList<OrchestrationLogEntry>)[]);
+}
+
+public class StubSquadDataProvider : ISquadDataProvider
+{
+    public TeamRoster? RosterResult { get; set; }
+    public IReadOnlyList<OrchestrationLogEntry>? LogResult { get; set; }
+    public IReadOnlyList<DecisionEntry>? DecisionResult { get; set; }
+    public IReadOnlyList<Skill>? SkillResult { get; set; }
+    public DashboardData? DashboardResult { get; set; }
+
+    public Task<TeamRoster> GetRosterAsync(CancellationToken ct = default) =>
+        Task.FromResult(RosterResult ?? new TeamRoster("Stub"));
+
+    public Task<IReadOnlyList<OrchestrationLogEntry>> GetLogEntriesAsync(CancellationToken ct = default) =>
+        Task.FromResult(LogResult ?? (IReadOnlyList<OrchestrationLogEntry>)[]);
+
+    public Task<IReadOnlyList<DecisionEntry>> GetDecisionsAsync(CancellationToken ct = default) =>
+        Task.FromResult(DecisionResult ?? (IReadOnlyList<DecisionEntry>)[]);
+
+    public Task<IReadOnlyList<Skill>> GetSkillsAsync(CancellationToken ct = default) =>
+        Task.FromResult(SkillResult ?? (IReadOnlyList<Skill>)[]);
+
+    public Task<DashboardData> GetDashboardAsync(CancellationToken ct = default) =>
+        Task.FromResult(DashboardResult ?? new DashboardData(
+            new TeamSummary(0, 0, []),
+            [], [], [], []));
+}
+
+/// <summary>Helper to build ServiceProvider with stubs.</summary>
+public static class StubServiceProviderFactory
+{
+    public static ServiceProvider Create(
+        ITeamService? team = null,
+        IDecisionService? decisions = null,
+        ISkillService? skills = null,
+        IOrchestrationLogService? log = null,
+        ISquadDataProvider? squadData = null) =>
+        new(
+            squadData ?? new StubSquadDataProvider(),
+            team ?? new StubTeamService(),
+            decisions ?? new StubDecisionService(),
+            skills ?? new StubSkillService(),
+            log ?? new StubOrchestrationLogService());
+}

--- a/tests/SquadTUI.Tests/Unit/Models/ModelTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Models/ModelTests.cs
@@ -1,3 +1,5 @@
+using LanguageExt;
+using static LanguageExt.Prelude;
 using SquadTUI.Models;
 
 namespace SquadTUI.Tests.Unit.Models;
@@ -12,17 +14,17 @@ public class ModelTests
     }
 
     [Fact]
-    public void SquadMember_DefaultsNullCurrentTask()
+    public void SquadMember_DefaultsNoneCurrentTask()
     {
         var member = new SquadMember("Test", "Dev");
-        Assert.Null(member.CurrentTask);
+        Assert.True(member.CurrentTask.IsNone);
     }
 
     [Fact]
-    public void SquadMember_DefaultsNullCharterPath()
+    public void SquadMember_DefaultsNoneCharterPath()
     {
         var member = new SquadMember("Test", "Dev");
-        Assert.Null(member.CharterPath);
+        Assert.True(member.CharterPath.IsNone);
     }
 
     [Fact]
@@ -33,10 +35,10 @@ public class ModelTests
     }
 
     [Fact]
-    public void SquadTask_DefaultsNullAssignee()
+    public void SquadTask_DefaultsNoneAssignee()
     {
         var task = new SquadTask("t1", "Test Task");
-        Assert.Null(task.Assignee);
+        Assert.True(task.Assignee.IsNone);
     }
 
     [Fact]
@@ -95,13 +97,13 @@ public class ModelTests
     [Fact]
     public void Skill_StoresAllFields()
     {
-        var skill = new Skill("test", "desc", "manual", "high", "body", "test-slug");
+        var skill = new Skill("test", "desc", Some("manual"), "high", Some("body"), Some("test-slug"));
         Assert.Equal("test", skill.Name);
         Assert.Equal("desc", skill.Description);
-        Assert.Equal("manual", skill.Source);
+        Assert.Equal(Some("manual"), skill.Source);
         Assert.Equal("high", skill.Confidence);
-        Assert.Equal("body", skill.Content);
-        Assert.Equal("test-slug", skill.Slug);
+        Assert.Equal(Some("body"), skill.Content);
+        Assert.Equal(Some("test-slug"), skill.Slug);
     }
 
     [Fact]

--- a/tests/SquadTUI.Tests/Unit/SampleDataTests.cs
+++ b/tests/SquadTUI.Tests/Unit/SampleDataTests.cs
@@ -1,3 +1,4 @@
+using LanguageExt;
 using SquadTUI.Tests.Fixtures;
 
 namespace SquadTUI.Tests.Unit;
@@ -10,8 +11,7 @@ public class SampleDataTests
         var memberNames = SampleData.Members.Select(m => m.Name).ToHashSet();
         foreach (var task in SampleData.Tasks)
         {
-            if (task.Assignee is not null)
-                Assert.Contains(task.Assignee, memberNames);
+            task.Assignee.IfSome(a => Assert.Contains(a, memberNames));
         }
     }
 

--- a/tests/SquadTUI.Tests/Unit/Screens/RosterScreenTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Screens/RosterScreenTests.cs
@@ -56,10 +56,10 @@ public class RosterScreenTests
     }
 
     [Fact]
-    public void ShowEmoji_DefaultsFalse()
+    public void ShowEmoji_DefaultsTrue()
     {
         var settings = new AppSettings();
-        Assert.False(settings.ShowEmoji);
+        Assert.True(settings.ShowEmoji);
     }
 
     [Fact]

--- a/tests/SquadTUI.Tests/Unit/Screens/SettingsScreenTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Screens/SettingsScreenTests.cs
@@ -39,10 +39,10 @@ public class SettingsScreenTests
     }
 
     [Fact]
-    public void AppState_Settings_ShowEmoji_DefaultsFalse()
+    public void AppState_Settings_ShowEmoji_DefaultsTrue()
     {
         var state = new AppState();
-        Assert.False(state.Settings.ShowEmoji);
+        Assert.True(state.Settings.ShowEmoji);
     }
 
     [Fact]

--- a/tests/SquadTUI.Tests/Unit/Services/DataBridgeMemberTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/DataBridgeMemberTests.cs
@@ -1,31 +1,17 @@
 using LanguageExt;
-using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using SquadTUI.Models;
 using SquadTUI.Services;
+using SquadTUI.Tests.Stubs;
 
 namespace SquadTUI.Tests.Unit.Services;
 
 public class DataBridgeMemberTests
 {
-    private static ServiceProvider CreateServiceProvider(ITeamService? teamService = null)
-    {
-        teamService ??= Substitute.For<ITeamService>();
-        var decisionService = Substitute.For<IDecisionService>();
-        var skillService = Substitute.For<ISkillService>();
-        var logService = Substitute.For<IOrchestrationLogService>();
-        var squadData = Substitute.For<ISquadDataProvider>();
-        return new ServiceProvider(squadData, teamService, decisionService, skillService, logService);
-    }
-
     [Fact]
     public async Task AddMemberAsync_ReturnsRight_OnSuccess()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.AddMemberAsync("Basher", "QA", Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
-
-        var sp = CreateServiceProvider(teamService);
+        var teamService = new StubTeamService();
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.AddMemberAsync("Basher", "QA");
@@ -35,11 +21,8 @@ public class DataBridgeMemberTests
     [Fact]
     public async Task RemoveMemberAsync_ReturnsRight_OnSuccess()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.RemoveMemberAsync("Basher", Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
-
-        var sp = CreateServiceProvider(teamService);
+        var teamService = new StubTeamService();
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.RemoveMemberAsync("Basher");
@@ -49,11 +32,11 @@ public class DataBridgeMemberTests
     [Fact]
     public async Task AddMemberAsync_ReturnsLeft_OnError()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.AddMemberAsync("Basher", "QA", Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("team.md does not exist"));
-
-        var sp = CreateServiceProvider(teamService);
+        var teamService = new StubTeamService
+        {
+            AddMemberException = new InvalidOperationException("team.md does not exist")
+        };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.AddMemberAsync("Basher", "QA");
@@ -63,11 +46,11 @@ public class DataBridgeMemberTests
     [Fact]
     public async Task RemoveMemberAsync_ReturnsLeft_OnError()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.RemoveMemberAsync("Basher", Arg.Any<CancellationToken>())
-            .ThrowsAsync(new IOException("Permission denied"));
-
-        var sp = CreateServiceProvider(teamService);
+        var teamService = new StubTeamService
+        {
+            RemoveMemberException = new IOException("Permission denied")
+        };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.RemoveMemberAsync("Basher");
@@ -77,11 +60,8 @@ public class DataBridgeMemberTests
     [Fact]
     public async Task AddMemberAsync_ErrorContainsServiceName()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.AddMemberAsync("X", "Y", Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("boom"));
-
-        var sp = CreateServiceProvider(teamService);
+        var teamService = new StubTeamService { AddMemberException = new Exception("boom") };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.AddMemberAsync("X", "Y");
@@ -91,11 +71,8 @@ public class DataBridgeMemberTests
     [Fact]
     public async Task RemoveMemberAsync_ErrorContainsServiceName()
     {
-        var teamService = Substitute.For<ITeamService>();
-        teamService.RemoveMemberAsync("X", Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("boom"));
-
-        var sp = CreateServiceProvider(teamService);
+        var teamService = new StubTeamService { RemoveMemberException = new Exception("boom") };
+        var sp = StubServiceProviderFactory.Create(team: teamService);
         var bridge = new DataBridge(sp);
 
         var result = await bridge.RemoveMemberAsync("X");

--- a/tests/SquadTUI.Tests/Unit/Services/SettingsServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/SettingsServiceTests.cs
@@ -12,7 +12,7 @@ public class SettingsServiceTests
         Assert.Equal("Ocean", settings.ThemeName);
         Assert.True(settings.VimBindings);
         Assert.True(settings.MouseEnabled);
-        Assert.False(settings.ShowEmoji);
+        Assert.True(settings.ShowEmoji);
         Assert.True(settings.MarkdownRendering);
         Assert.Equal("Dashboard", settings.DefaultScreen);
     }

--- a/tests/SquadTUI.Tests/Unit/Services/SkillServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/SkillServiceTests.cs
@@ -1,3 +1,5 @@
+using LanguageExt;
+using static LanguageExt.Prelude;
 using SquadTUI.Services;
 
 namespace SquadTUI.Tests.Unit.Services;
@@ -49,9 +51,9 @@ public class SkillServiceTests : IDisposable
         var skill = skills.First();
         Assert.Equal("Test Skill", skill.Name);
         Assert.Equal("A test skill", skill.Description);
-        Assert.Equal("manual", skill.Source);
+        Assert.Equal(Some("manual"), skill.Source);
         Assert.Equal("high", skill.Confidence);
-        Assert.Equal("test-skill", skill.Slug);
+        Assert.Equal(Some("test-skill"), skill.Slug);
     }
 
     [Fact]
@@ -127,7 +129,7 @@ public class SkillServiceTests : IDisposable
 
         Assert.NotNull(skill);
         Assert.Equal("Code Review", skill!.Name);
-        Assert.Equal("code-review", skill.Slug);
+        Assert.Equal(Some("code-review"), skill.Slug);
     }
 
     [Fact]
@@ -148,8 +150,8 @@ public class SkillServiceTests : IDisposable
         var svc = new SkillService(SquadDir);
         var skills = await svc.GetSkillsAsync();
 
-        Assert.Contains("Body content line 1.", skills.First().Content);
-        Assert.Contains("Body content line 2.", skills.First().Content);
+        Assert.Contains("Body content line 1.", skills.First().Content.IfNone(""));
+        Assert.Contains("Body content line 2.", skills.First().Content.IfNone(""));
     }
 
     [Fact]

--- a/tests/SquadTUI.Tests/Unit/Services/SquadDataProviderTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/SquadDataProviderTests.cs
@@ -1,22 +1,11 @@
-using NSubstitute;
 using SquadTUI.Models;
 using SquadTUI.Services;
+using SquadTUI.Tests.Stubs;
 
 namespace SquadTUI.Tests.Unit.Services;
 
 public class SquadDataProviderTests
 {
-    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
-    private readonly IOrchestrationLogService _logService = Substitute.For<IOrchestrationLogService>();
-    private readonly IDecisionService _decisionService = Substitute.For<IDecisionService>();
-    private readonly ISkillService _skillService = Substitute.For<ISkillService>();
-    private readonly SquadDataProvider _provider;
-
-    public SquadDataProviderTests()
-    {
-        _provider = new SquadDataProvider(_teamService, _logService, _decisionService, _skillService);
-    }
-
     [Fact]
     public async Task GetDashboardAsync_AggregatesAllServices()
     {
@@ -32,11 +21,12 @@ public class SquadDataProviderTests
             new(DateTimeOffset.Now, "2026-01-01", "kickoff", ["Danny"], "Summary", [], [])
         };
 
-        _teamService.GetRosterAsync(Arg.Any<CancellationToken>()).Returns(roster);
-        _decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>()).Returns(decisions);
-        _logService.GetEntriesAsync(Arg.Any<CancellationToken>()).Returns(logEntries);
+        var teamService = new StubTeamService { RosterResult = roster };
+        var decisionService = new StubDecisionService { Result = decisions };
+        var logService = new StubOrchestrationLogService { Result = logEntries };
 
-        var dashboard = await _provider.GetDashboardAsync();
+        var provider = new SquadDataProvider(teamService, logService, decisionService, new StubSkillService());
+        var dashboard = await provider.GetDashboardAsync();
 
         Assert.NotNull(dashboard.Team);
         Assert.NotEmpty(dashboard.Decisions);
@@ -53,15 +43,13 @@ public class SquadDataProviderTests
             new("Scribe", "Logger", MemberStatus.Idle),
         };
         var roster = new TeamRoster("Test", null, members);
+        var teamService = new StubTeamService { RosterResult = roster };
 
-        _teamService.GetRosterAsync(Arg.Any<CancellationToken>()).Returns(roster);
-        _decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>()).Returns(new List<DecisionEntry>());
-        _logService.GetEntriesAsync(Arg.Any<CancellationToken>()).Returns(new List<OrchestrationLogEntry>());
-
-        var dashboard = await _provider.GetDashboardAsync();
+        var provider = new SquadDataProvider(teamService, new StubOrchestrationLogService(), new StubDecisionService(), new StubSkillService());
+        var dashboard = await provider.GetDashboardAsync();
 
         Assert.Equal(3, dashboard.Team.TotalMembers);
-        Assert.Equal(2, dashboard.Team.ActiveMembers); // Active + Working
+        Assert.Equal(2, dashboard.Team.ActiveMembers);
     }
 
     [Fact]
@@ -77,11 +65,11 @@ public class SquadDataProviderTests
             new(DateTimeOffset.Now, "2026-01-01", "kickoff", ["Danny"], "Summary", [], [])
         };
 
-        _teamService.GetRosterAsync(Arg.Any<CancellationToken>()).Returns(roster);
-        _decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>()).Returns(new List<DecisionEntry>());
-        _logService.GetEntriesAsync(Arg.Any<CancellationToken>()).Returns(logEntries);
+        var teamService = new StubTeamService { RosterResult = roster };
+        var logService = new StubOrchestrationLogService { Result = logEntries };
 
-        var dashboard = await _provider.GetDashboardAsync();
+        var provider = new SquadDataProvider(teamService, logService, new StubDecisionService(), new StubSkillService());
+        var dashboard = await provider.GetDashboardAsync();
 
         Assert.Single(dashboard.Activity);
         Assert.Equal("Danny", dashboard.Activity[0].MemberName);
@@ -92,9 +80,10 @@ public class SquadDataProviderTests
     public async Task GetRosterAsync_DelegatesToTeamService()
     {
         var roster = new TeamRoster("Test");
-        _teamService.GetRosterAsync(Arg.Any<CancellationToken>()).Returns(roster);
+        var teamService = new StubTeamService { RosterResult = roster };
 
-        var result = await _provider.GetRosterAsync();
+        var provider = new SquadDataProvider(teamService, new StubOrchestrationLogService(), new StubDecisionService(), new StubSkillService());
+        var result = await provider.GetRosterAsync();
 
         Assert.Equal(roster, result);
     }
@@ -103,9 +92,10 @@ public class SquadDataProviderTests
     public async Task GetDecisionsAsync_DelegatesToDecisionService()
     {
         var decisions = new List<DecisionEntry> { new("D1", "2026-01-01", "Danny", "Content") };
-        _decisionService.GetDecisionsAsync(Arg.Any<CancellationToken>()).Returns(decisions);
+        var decisionService = new StubDecisionService { Result = decisions };
 
-        var result = await _provider.GetDecisionsAsync();
+        var provider = new SquadDataProvider(new StubTeamService(), new StubOrchestrationLogService(), decisionService, new StubSkillService());
+        var result = await provider.GetDecisionsAsync();
 
         Assert.Equal(decisions, result);
     }
@@ -117,9 +107,10 @@ public class SquadDataProviderTests
         {
             new(DateTimeOffset.Now, "2026-01-01", "test", [], "Summary", [], [])
         };
-        _logService.GetEntriesAsync(Arg.Any<CancellationToken>()).Returns(logs);
+        var logService = new StubOrchestrationLogService { Result = logs };
 
-        var result = await _provider.GetLogEntriesAsync();
+        var provider = new SquadDataProvider(new StubTeamService(), logService, new StubDecisionService(), new StubSkillService());
+        var result = await provider.GetLogEntriesAsync();
 
         Assert.Equal(logs, result);
     }
@@ -128,9 +119,10 @@ public class SquadDataProviderTests
     public async Task GetSkillsAsync_DelegatesToSkillService()
     {
         var skills = new List<Skill> { new("test", "desc") };
-        _skillService.GetSkillsAsync(Arg.Any<CancellationToken>()).Returns(skills);
+        var skillService = new StubSkillService { Result = skills };
 
-        var result = await _provider.GetSkillsAsync();
+        var provider = new SquadDataProvider(new StubTeamService(), new StubOrchestrationLogService(), new StubDecisionService(), skillService);
+        var result = await provider.GetSkillsAsync();
 
         Assert.Equal(skills, result);
     }

--- a/tests/SquadTUI.Tests/Unit/Services/TeamServiceTests.cs
+++ b/tests/SquadTUI.Tests/Unit/Services/TeamServiceTests.cs
@@ -1,3 +1,4 @@
+using LanguageExt;
 using SquadTUI.Models;
 using SquadTUI.Services;
 
@@ -234,12 +235,12 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        Assert.NotNull(roster.Members!.First().CharterPath);
-        Assert.True(File.Exists(roster.Members!.First().CharterPath));
+        Assert.True(roster.Members!.First().CharterPath.IsSome);
+        roster.Members!.First().CharterPath.IfSome(p => Assert.True(File.Exists(p)));
     }
 
     [Fact]
-    public async Task ParseTeamMd_CharterPathNullWhenFileDoesNotExist()
+    public async Task ParseTeamMd_CharterPathNoneWhenFileDoesNotExist()
     {
         WriteTeamFile("""
             # Team Roster
@@ -254,6 +255,6 @@ public class TeamServiceTests : IDisposable
         var svc = new TeamService(SquadDir);
         var roster = await svc.GetRosterAsync();
 
-        Assert.Null(roster.Members!.First().CharterPath);
+        Assert.True(roster.Members!.First().CharterPath.IsNone);
     }
 }


### PR DESCRIPTION
## Sprint 16: UX Refinement

### Changes

**Solaire (Agent Lead)**
- Case-insensitive key bindings — all letter keys now bind both plain and Shift variants
- Emoji display defaults to ON
- Settings modal overlay (S key) — replaces screen navigation, includes theme, vim bindings, mouse support, emoji, markdown, default screen settings

**Siegmeyer (Frontend)**
- Tab padding increased (3 spaces each side)
- Scrollable markdown with j/k navigation and scroll position indicator
- Table rendering with Unicode box-drawing characters (┌─┬─┐ etc.)
- ProgressBarRenderer with themed █░ bars and auto-coloring
- Removed hardcoded GetConfidenceLevel — now uses Skill.Confidence from SKILL.md

**Andre (Backend)**
- Option types replacing nullable strings (SquadMember.CurrentTask/CharterPath, SquadTask.Description/Assignee, Skill.Source/Content/Slug)
- Query expressions replacing LINQ method syntax where readable
- Expression-bodied members for single-expression methods
- Skill.Confidence field with SKILL.md frontmatter parsing

**NSubstitute Removal**
- Replaced all 46 Substitute.For calls with hand-written stubs
- Created StubServices.cs with 5 configurable stub classes
- Removed NSubstitute package reference
- Zero mocking framework dependencies

### Test Results
- **761 tests passing, 0 failures**
- Build succeeds on all platforms